### PR TITLE
Strengthen out-of-season holiday filtering in discover recommendations

### DIFF
--- a/src/app/discover/service.py
+++ b/src/app/discover/service.py
@@ -92,8 +92,8 @@ PROVIDER_ARTWORK_HYDRATION_ROW_KEYS = {
     "all_time_greats_unseen",
     "coming_soon",
 }
-HOLIDAY_STRONG_TERMS = {"christmas", "xmas", "noel"}
-HOLIDAY_SOFT_TERMS = {"holiday", "holidays", "new year", "new years"}
+HOLIDAY_STRONG_TERMS = {"christmas", "xmas", "noel", "grinch", "krampus", "nutcracker"}
+HOLIDAY_SOFT_TERMS = {"holiday", "holidays", "new year", "new years", "jack frost", "santa claus"}
 COMFORT_DIVERSITY_DECAY = 0.92
 COMFORT_PHASE_LANE_QUOTA = 4
 COMFORT_PHASE_LANE_WINDOW = 6
@@ -2550,7 +2550,7 @@ def _apply_comfort_confidence(
             seasonal_adjustment = (
                 0.06 * holiday_strength
                 if holiday_window_active
-                else -0.14 * holiday_strength
+                else -0.40 * holiday_strength
             )
 
         phase_family_contribution = (


### PR DESCRIPTION
The previous out-of-season penalty (-0.14) was too weak to suppress Christmas movies (e.g. The Grinch, Jack Frost) in the "Top Picks For You" and "Comfort Rewatches" rows during non-holiday months. A highly-rated Christmas movie could score ~0.46 even after the penalty, still ranking in the top results.

Two changes:
- Increase the out-of-season penalty from -0.14 to -0.40, which drops a full-strength holiday item from ~0.60 to ~0.20, pushing it well below typical non-holiday candidates.
- Expand HOLIDAY_STRONG_TERMS to include "grinch", "krampus", and "nutcracker", and HOLIDAY_SOFT_TERMS to include "jack frost" and "santa claus", so iconic Christmas characters in titles are caught even when TMDB keyword tags are absent.

https://claude.ai/code/session_01XpYeZusWXu9yNUZiZMqzVw

## Summary
- Describe what changed and why.

## Validation
- List commands run and outcomes.

## Migration Sync Gate (Required for `dev` -> `latest` sync PRs)
- [ ] Conflicts resolved with upstream files preserved and fork behavior merged intentionally.
- [ ] Migration conflicts handled per policy (no rewrite of shared/released migrations).
- [ ] `cd src && python manage.py makemigrations --merge` run for affected apps.
- [ ] `cd src && python manage.py check_migration_hygiene --strict` passed.
- [ ] `scripts/replay_upgrade_matrix.sh --from-tag <previous_release_tag> --to-ref latest --db sqlite,postgres --with-drift-scenarios` passed.
- [ ] `coverage run src/manage.py test app users integrations lists events --parallel` passed.

## Notes
- Link relevant issues (for example: `Refs #101`).
