### PR TITLE
fix: handle empty source value in source_readable template filter

### DIFF
--- a/src/app/templatetags/app_tags.py
+++ b/src/app/templatetags/app_tags.py
@@ -196,7 +196,12 @@ def is_list(arg1):
 @register.filter
 def source_readable(source):
     """Return the readable source name."""
-    return Sources(source).label
+    if not source:
+        return ""
+    try:
+        return Sources(source).label
+    except ValueError:
+        return source
 
 
 @register.filter


### PR DESCRIPTION
## Bug
https://github.com/dannyvfilms/Yamtrack/issues/111 — Navigating to any TV season page returns a 500 error due to `ValueError: '' is not a valid Sources`.

## Fix
The `source_readable` template filter in `app_tags.py` passes the source value directly to `Sources(source)` without validation. When a season has an empty string as its source (which can happen with certain metadata provider configurations), the enum lookup raises a `ValueError` that crashes the entire page.

This PR adds:
1. An early return for empty/falsy source values (returns empty string)
2. A try/except around the enum conversion so unrecognized source values fall back to displaying the raw value instead of crashing

## Testing
- Empty source → returns `""` (page renders without error)
- Valid source like `"tmdb"` → returns `"The Movie Database"` (unchanged behavior)
- Unknown source like `"custom"` → returns `"custom"` (graceful fallback)

Happy to address any feedback.

Greetings, saschabuehrle