### PR TITLE
Fix 500 error on podcast detail page due to missing source_url fields

### DIFF
--- a/src/app/views.py
+++ b/src/app/views.py
@@ -4050,6 +4050,9 @@ def media_details(
                 },
                 "episodes": episode_list,  # Use episodes key like TV seasons
             }
+            media_metadata.setdefault("source_url", None)
+            media_metadata.setdefault("tracking_source_url", None)
+            media_metadata.setdefault("display_source_url", None)
 
             # For pagination, calculate if there are more episodes
             total_episodes_count = episodes.count()


### PR DESCRIPTION
## Summary
Bug: Visiting a podcast detail page causes a 500 error because media_metadata is missing source_url, tracking_source_url, and display_source_url keys that media_details.html expects.
Fix: Added setdefault calls for these three keys in the podcast code path in views.py, consistent with the existing pattern used for cast, crew, and studios_full..

## Notes
- fixes #118 
