### PR TITLE
Steam: update existing games in overwrite mode instead of delete+recreate

### DIFF
--- a/src/integrations/imports/steam.py
+++ b/src/integrations/imports/steam.py
@@ -48,6 +48,7 @@ class SteamImporter:
         self.existing_media = helpers.get_existing_media(user)
 
         self.to_update = []
+        self.to_update_meta = []
 
         self.bulk_media = defaultdict(list)
 
@@ -79,6 +80,18 @@ class SteamImporter:
             logger.info(
                 "Updated %d existing games for user %s",
                 len(self.to_update),
+                self.user.username,
+            )
+
+        # Update item metadata
+        if self.to_update_meta:
+            app.models.Item.objects.bulk_update(
+                self.to_update_meta,
+                fields=['title', 'image']
+            )
+            logger.info(
+                "Updated metadata for %d items for user %s",
+                len(self.to_update_meta),
                 self.user.username,
             )
 
@@ -195,6 +208,11 @@ class SteamImporter:
                     if existing.status not in {Status.COMPLETED.value, Status.DROPPED.value}:
                         existing.status = self._determine_game_status(playtime_forever, playtime_2weeks)
                     self.to_update.append(existing)
+                
+                item = existing.item
+                item.title = igdb_game["title"]
+                item.image = igdb_game["image"]
+                self.to_update_meta.append(item)
                 # In "new" mode, skip existing games
             else: 
                 item, _ = app.models.Item.objects.get_or_create(

--- a/src/integrations/imports/steam.py
+++ b/src/integrations/imports/steam.py
@@ -47,8 +47,6 @@ class SteamImporter:
 
         self.existing_media = helpers.get_existing_media(user)
 
-        self.to_delete = defaultdict(lambda: defaultdict(set))
-
         self.to_update = []
 
         self.bulk_media = defaultdict(list)
@@ -70,7 +68,6 @@ class SteamImporter:
         for game_data in owned_games:
             self._process_game(game_data)
 
-        helpers.cleanup_existing_media(self.to_delete, self.user)
         helpers.bulk_create_media(self.bulk_media, self.user)
 
         # Update existing games
@@ -195,21 +192,11 @@ class SteamImporter:
                 if self.mode == "overwrite":
                     existing.progress = playtime_forever
                     # Conscious choice: User manually set status to Completed/Dropped, we should not change it
-                    if existing.status not in (Status.COMPLETED.value, Status.DROPPED.value):
+                    if existing.status not in {Status.COMPLETED.value, Status.DROPPED.value}:
                         existing.status = self._determine_game_status(playtime_forever, playtime_2weeks)
                     self.to_update.append(existing)
                 # In "new" mode, skip existing games
             else: 
-                if not helpers.should_process_media(
-                    self.existing_media,
-                    self.to_delete,
-                    MediaTypes.GAME.value,
-                    Sources.IGDB.value,
-                    media_id,
-                    self.mode,
-                ):
-                    return
-                
                 item, _ = app.models.Item.objects.get_or_create(
                     media_id=media_id,
                     source=Sources.IGDB.value,

--- a/src/integrations/imports/steam.py
+++ b/src/integrations/imports/steam.py
@@ -15,6 +15,7 @@ from integrations.imports.helpers import MediaImportError, MediaImportUnexpected
 logger = logging.getLogger(__name__)
 
 STEAM_API_BASE_URL = "https://api.steampowered.com"
+IMPORT_NOTE = "Imported from Steam"
 
 
 def importer(steam_id, user, mode):
@@ -48,6 +49,8 @@ class SteamImporter:
 
         self.to_delete = defaultdict(lambda: defaultdict(set))
 
+        self.to_update = []
+
         self.bulk_media = defaultdict(list)
 
         logger.info(
@@ -69,6 +72,18 @@ class SteamImporter:
 
         helpers.cleanup_existing_media(self.to_delete, self.user)
         helpers.bulk_create_media(self.bulk_media, self.user)
+
+        # Update existing games
+        if self.to_update:
+            app.models.Game.objects.bulk_update(
+                self.to_update,
+                fields=['progress', 'status']
+            )
+            logger.info(
+                "Updated %d existing games for user %s",
+                len(self.to_update),
+                self.user.username,
+            )
 
         imported_counts = {
             media_type: len(media_list)
@@ -174,43 +189,48 @@ class SteamImporter:
                 )
                 return
 
-            if not helpers.should_process_media(
-                self.existing_media,
-                self.to_delete,
-                MediaTypes.GAME.value,
-                Sources.IGDB.value,
-                str(igdb_game["media_id"]),
-                self.mode,
-            ):
-                return
+            media_id = str(igdb_game["media_id"])
+            existing = self.existing_media[MediaTypes.GAME.value][Sources.IGDB.value].get(media_id)
+            if existing:
+                if self.mode == "overwrite":
+                    existing.progress = playtime_forever
+                    # Conscious choice: User manually set status to Completed/Dropped, we should not change it
+                    if existing.status not in (Status.COMPLETED.value, Status.DROPPED.value):
+                        existing.status = self._determine_game_status(playtime_forever, playtime_2weeks)
+                    self.to_update.append(existing)
+                # In "new" mode, skip existing games
+            else: 
+                if not helpers.should_process_media(
+                    self.existing_media,
+                    self.to_delete,
+                    MediaTypes.GAME.value,
+                    Sources.IGDB.value,
+                    media_id,
+                    self.mode,
+                ):
+                    return
+                
+                item, _ = app.models.Item.objects.get_or_create(
+                    media_id=media_id,
+                    source=Sources.IGDB.value,
+                    media_type=MediaTypes.GAME.value,
+                    defaults={
+                        "title": igdb_game["title"],
+                        "image": igdb_game["image"],
+                    },
+                )
+                game = app.models.Game(
+                    item=item,
+                    user=self.user,
+                    status=self._determine_game_status(playtime_forever, playtime_2weeks),
+                    score=None,
+                    progress=playtime_forever,
+                    notes=IMPORT_NOTE,
+                    start_date=None,
+                    end_date=None,
+                )
 
-            # Use IGDB data if found
-            item, _ = app.models.Item.objects.get_or_create(
-                media_id=str(igdb_game["media_id"]),
-                source=Sources.IGDB.value,
-                media_type=MediaTypes.GAME.value,
-                defaults={
-                    "title": igdb_game["title"],
-                    "image": igdb_game["image"],
-                },
-            )
-
-            # Determine status based on playtime
-            status = self._determine_game_status(playtime_forever, playtime_2weeks)
-
-            # Create game object
-            game = app.models.Game(
-                item=item,
-                user=self.user,
-                status=status,
-                score=None,
-                progress=playtime_forever,
-                notes="Imported from Steam",
-                start_date=None,
-                end_date=None,
-            )
-
-            self.bulk_media[MediaTypes.GAME.value].append(game)
+                self.bulk_media[MediaTypes.GAME.value].append(game)
 
         except services.ProviderAPIError as e:
             msg = str(e).lower()


### PR DESCRIPTION
This PR changes the Steam importer to **update** existing games (playtime, status, metadata) rather than deleting and recreating them. This preserves user‑set notes, scores, and the `Dropped`/`Completed` statuses of games.

In `overwrite` mode, the Steam importer will still:

- Update game metadata  
- Update game playtime  
- Import new games
- Set status to `Planning` for newly imported games  
- Set status to `Paused` for games with playtime but no recent activity, **unless** the previous status was `Dropped` or `Completed`  
- Set status to `In Progress` for games with recent playtime, **unless** the previous status was `Dropped` or `Completed`

PR was originally opened on the base repo [here](https://github.com/FuzzyGrim/Yamtrack/pull/1283). However, I have decided to reopen it here, since I use this fork and the activity on the base repo is slow. Not to mention how long it will be before this repo is synced with it.

I have tested the changes locally on windows with msys2.