### PR TITLE
Add support for X-Forwarded-* headers in order to deal better with reverse proxy;

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,13 @@ environment:
 
 Multiple origins can be specified with commas, for example `https://yamtrack.mydomain.com,https://yamtrack-alt.mydomain.com`.
 
+If Yamtrack does not generate the correct callback URLs for authenticating with Anilist and other imports, add this to your environment variables:
+
+```yaml
+environment:
+  - USE_X_FORWARDED=True
+```
+
 ### Docker Image Tags
 
 The Docker image is available at `ghcr.io/dannyvfilms/yamtrack` with these tags:

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -121,7 +121,11 @@ if BASE_URL:
     # send cookies with all requests under the base URL prefix
     CSRF_COOKIE_PATH = BASE_URL
 
-SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+USE_X_FORWARDED = config("USE_X_FORWARDED", default=False, cast=bool)
+
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https") if (config("USE_X_FORWARDED_PROTO", default=USE_X_FORWARDED, cast=bool)) else None
+USE_X_FORWARDED_HOST = config("USE_X_FORWARDED_HOST", default=USE_X_FORWARDED, cast=bool)
+USE_X_FORWARDED_PORT = config("USE_X_FORWARDED_PORT", default=USE_X_FORWARDED, cast=bool)
 
 # Application definition
 


### PR DESCRIPTION
Solves FuzzyGrim/Yamtrack#1023 and generally makes request.build_absolute_uri (used in other imports as well) use the correct host by adding these settings:
- USE_X_FORWARDED_PROTO for X-Forwarded-Proto.
- USE_X_FORWARDED_HOST for X-Forwarded-Host
- USE_X_FORWARDED_PORT for X-Forwarded-Port
- USE_X_FORWARDED (defaults to false) to set the default of the other three.