### PR TITLE
Fix HLTB imports without start date columns

### DIFF
--- a/src/integrations/imports/hltb.py
+++ b/src/integrations/imports/hltb.py
@@ -226,7 +226,7 @@ class HowLongToBeatImporter:
         }
 
         for field, status in status_mapping.items():
-            if row[field] == "X":
+            if row.get(field) in {"X", "✓"}:
                 return status.value
 
         return Status.COMPLETED.value
@@ -271,8 +271,8 @@ class HowLongToBeatImporter:
                 default=0,
             ),
             status=self._determine_status(row),
-            start_date=self._parse_hltb_date(row["Start Date"]),
-            end_date=self._parse_hltb_date(row["Completion Date"]),
+            start_date=self._parse_hltb_date(row.get("Start Date")),
+            end_date=self._parse_hltb_date(row.get("Completion Date")),
             notes=self._format_notes(row),
         )
         instance._history_date = updated_at

--- a/src/integrations/tests/imports/test_hltb.py
+++ b/src/integrations/tests/imports/test_hltb.py
@@ -1,11 +1,13 @@
 from datetime import UTC, datetime
 from pathlib import Path
+from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 
 from app.models import (
     Game,
+    Status,
 )
 from integrations.imports import (
     hltb,
@@ -22,7 +24,19 @@ class ImportHowLongToBeat(TestCase):
 
     def setUp(self):
         """Create user for the tests."""
-        self.credentials = {"username": "test", "password": "12345"}
+        self.search_patcher = patch("app.providers.services.search")
+        self.mock_search = self.search_patcher.start()
+        self.addCleanup(self.search_patcher.stop)
+        self.mock_search.return_value = {
+            "results": [
+                {
+                    "media_id": "re7",
+                    "title": "Resident Evil 7: Biohazard",
+                    "image": "",
+                },
+            ],
+        }
+        self.credentials = {"username": "test", "password": "***"}
         self.user = get_user_model().objects.create_user(**self.credentials)
         with Path(mock_path / "import_hltb_game.csv").open("rb") as file:
             self.import_results = hltb.importer(file, self.user, "new")
@@ -39,3 +53,26 @@ class ImportHowLongToBeat(TestCase):
             game.history.first().history_date,
             datetime(2024, 2, 9, 15, 54, 48, tzinfo=UTC),
         )
+
+    def test_import_old_csv_without_start_date(self):
+        """Test old HLTB exports without Start Date can still import."""
+        self.mock_search.return_value = {
+            "results": [
+                {
+                    "media_id": "2048",
+                    "title": "2048",
+                    "image": "",
+                },
+            ],
+        }
+        user = get_user_model().objects.create_user(username="old-hltb")
+
+        with Path(mock_path / "import_hltb_game_missing_start_date.csv").open(
+            "rb",
+        ) as file:
+            hltb.importer(file, user, "new")
+
+        game = Game.objects.get(user=user, item__media_id="2048")
+        self.assertIsNone(game.start_date)
+        self.assertIsNone(game.end_date)
+        self.assertEqual(game.status, Status.DROPPED.value)

--- a/src/integrations/tests/mock_data/import_hltb_game_missing_start_date.csv
+++ b/src/integrations/tests/mock_data/import_hltb_game_missing_start_date.csv
@@ -1,0 +1,2 @@
+"Title","Platform","Playing","Backlog","Replay","CP","Paused","Priority","Completed","Retired","Progress","Main Story","Main Story Notes","Main + Extras","Main + Extras Notes","Completionist","Completionist Notes","Speed Any%","Speed Any% Notes","Speed 100%","Speed 100% Notes","Co-Op","Multi-Player","General Notes","Storefront","Review","Review Notes","Added","Updated"
+2048,"Mobile","","","","","","","","✓","--","--","","--","","--","","--","","--","","--","--","Played around 2014.","",0,"",2023-05-09 15:03:09,2023-05-09 15:03:09


### PR DESCRIPTION
## Summary
- Handle older HowLongToBeat CSV exports that do not include `Start Date` / `Completion Date` columns.
- Treat missing optional date columns as empty values instead of raising `KeyError`.
- Accept the older `✓` status marker and add regression coverage for the old CSV shape.

## Validation
- Validated on Hermes remote worker via `hw-remote`; job `20260502T212012Z-ad33701c`; log `/home/ubuntu/logs/20260502T212012Z-ad33701c.log`.
- Source was synced with `.env` / `.env.*` excluded; no local secrets copied to the worker.
- Passed: `python src/manage.py test integrations.tests.imports.test_hltb --verbosity 1`
- Passed: `ruff check src/integrations/imports/hltb.py src/integrations/tests/imports/test_hltb.py`

## Migration Sync Gate (Required for `dev` -> `latest` sync PRs)
Not applicable; this is a focused importer bugfix and does not modify migrations.

## Notes
Refs #184
