### PR TITLE
Fix/log time on click

### DIFF
--- a/src/static/js/mediaStatusDateHandler.js
+++ b/src/static/js/mediaStatusDateHandler.js
@@ -176,9 +176,6 @@ document.addEventListener("alpine:init", () => {
         );
       }
 
-      // Get the current time in correct format based on input type
-      const now = this.getCurrentDateTime(endDateField);
-
       // Initial load handling - only auto-fill for new forms
       // For existing records, respect the saved values (even if empty)
       if (
@@ -188,7 +185,7 @@ document.addEventListener("alpine:init", () => {
         endDateField &&
         !endDateField.value
       ) {
-        endDateField.value = now;
+        endDateField.value = this.getCurrentDateTime(endDateField);
         this.autoFilled.end_date = true;
       } else if (
         isNewForm &&
@@ -197,7 +194,7 @@ document.addEventListener("alpine:init", () => {
         startDateField &&
         !startDateField.value
       ) {
-        startDateField.value = now;
+        startDateField.value = this.getCurrentDateTime(startDateField);
         this.autoFilled.start_date = true;
       }
 
@@ -235,7 +232,7 @@ document.addEventListener("alpine:init", () => {
             !endDateField.value &&
             !isReturningToOriginalCompleted
           ) {
-            endDateField.value = now;
+            endDateField.value = this.getCurrentDateTime(endDateField);
             this.autoFilled.end_date = true;
           } else if (
             status === "In progress" &&
@@ -243,7 +240,7 @@ document.addEventListener("alpine:init", () => {
             !startDateField.value &&
             !isReturningToOriginalInProgress
           ) {
-            startDateField.value = now;
+            startDateField.value = this.getCurrentDateTime(startDateField);
             this.autoFilled.start_date = true;
           }
         });

--- a/src/templates/app/components/fill_track_episode.html
+++ b/src/templates/app/components/fill_track_episode.html
@@ -91,10 +91,10 @@
           <label class="block text-sm font-medium text-gray-300 mb-2">Watch Date</label>
 
           {# djlint:off #}
-          <div class="relative" x-data="{ 
-              inputDateTime: '{% if TRACK_TIME %}{% now "Y-m-d\TH:i" %}{% else %}{% now "Y-m-d" %}{% endif %}',
+          <div class="relative" x-data="{
+              inputDateTime: '',
               inputType: '{% if TRACK_TIME %}datetime-local{% else %}date{% endif %}'
-          }">
+          }" x-effect="if (trackOpen) { const d = new Date(); inputDateTime = inputType === 'datetime-local' ? new Date(d.getTime() - d.getTimezoneOffset() * 60000).toISOString().slice(0, 16) : d.toISOString().slice(0, 10) }">
             <input class="w-full p-3 bg-[#343a40] rounded-md text-white border border-gray-600 focus:outline-none focus:ring-2 focus:ring-[#4a9eff] appearance-none"
                    x-bind:type="inputType"
                    name="end_date"

--- a/src/templates/app/components/fill_track_song.html
+++ b/src/templates/app/components/fill_track_song.html
@@ -209,10 +209,10 @@
           </label>
 
           {# djlint:off #}
-          <div class="relative" x-data="{ 
-              inputDateTime: '{% if TRACK_TIME %}{% now "Y-m-d\TH:i" %}{% else %}{% now "Y-m-d" %}{% endif %}',
+          <div class="relative" x-data="{
+              inputDateTime: '',
               inputType: '{% if TRACK_TIME %}datetime-local{% else %}date{% endif %}'
-          }">
+          }" x-effect="if (trackOpen) { const d = new Date(); inputDateTime = inputType === 'datetime-local' ? new Date(d.getTime() - d.getTimezoneOffset() * 60000).toISOString().slice(0, 16) : d.toISOString().slice(0, 10) }">
             <input class="w-full p-3 bg-[#343a40] rounded-md text-white border border-gray-600 focus:outline-none focus:ring-2 focus:ring-[#4a9eff] appearance-none"
                    x-bind:type="inputType"
                    name="end_date"


### PR DESCRIPTION
## Fix: Use current time when logging plays, not page load time

## Summary

When logging a new play, the datetime field was pre-filled with the time the page was loaded rather than the time the user actually interacted with the form. This affected two separate code paths:

- **Main track modal** (`mediaStatusDateHandler.js`): The current time was captured once into a `const now` variable during Alpine.js component initialisation and reused for all subsequent writes — including inside the status-change event listener, which could fire minutes after the page loaded.
- **Episode track modal** (`fill_track_episode.html`,`fill_track_song.html` ): The watch date was set server-side using Django's `{% now %}` template tag, baking the page-render time into the HTML before the user had even opened the modal.

## Changes

- `src/static/js/mediaStatusDateHandler.js`: Removed the upfront `const now = getCurrentDateTime()` call and replaced each usage with a fresh `getCurrentDateTime()` call at the moment the field value is actually written.
- `src/templates/app/components/fill_track_episode.html` and `src/templates/app/components/fill_track_song.html`: Replaced the server-rendered `{% now %}` default with an Alpine `x-effect` that recomputes the current time (with timezone adjustment) each time the modal is opened. `fill_track_song.html` is shared between music album and podcast episode tracking.


## Testing

1. Open a show's season page and wait a minute or two before clicking to log an episode — the watch date should reflect the time you clicked, not the page load time.
2. On a media detail page, open the track modal, wait, then change the status to Completed or In Progress — the auto-filled date should match the time you changed the status.
