### PR TITLE
feat: show season names in season selector dropdown

### DIFF
--- a/src/app/views.py
+++ b/src/app/views.py
@@ -6445,7 +6445,10 @@ def _build_local_tv_with_seasons_metadata(
             )
             season_copy.setdefault("title", show_title)
             season_copy.setdefault("season_title", season_title)
-            season_copy.setdefault("season_header_title", season_title)
+            season_copy.setdefault(
+                "season_header_title",
+                season_copy.get("season_title") or season_title,
+            )
             season_copy.setdefault("media_id", media_id)
             season_copy.setdefault("media_type", MediaTypes.SEASON.value)
             season_copy.setdefault("source", source)

--- a/src/templates/app/media_details.html
+++ b/src/templates/app/media_details.html
@@ -132,7 +132,7 @@
                           {{ tv_season.season_number }}
                         </div>
                         <div class="flex-1 text-left">
-                          <div class="text-sm font-medium">{{ tv_season.season_header_title|default:tv_season.title }}</div>
+                          <div class="text-sm font-medium">{{ tv_season.season_title|default:tv_season.title }}</div>
                           <div class="text-xs text-gray-400">
                             {{ tv_season.max_progress }} Episode{{ tv_season.max_progress|pluralize }}
                             {% if tv_season.first_air_date %}• {{ tv_season.first_air_date|user_date_format:user }}{% endif %}


### PR DESCRIPTION
## Summary

- Season dropdown on TV show detail pages now shows the actual season name (e.g. "Fantasy High", "Never Stop Blowing Up") instead of the show title
- Falls back to "Season X" / "Specials" for shows where TMDB/TVDB only provides generic season names, so existing behaviour is unchanged for those
- Root cause: `season_title` (populated by the provider) was being ignored in favour of `season_header_title`, which is only set on the local-only data path and caused a 500 when used as a Django filter argument on the normal path

## Changes

- `src/templates/app/media_details.html` — use `season_title` in the dropdown item render instead of `season_header_title`
- `src/app/views.py` — also prefer provider `season_title` over generic fallback when building `season_header_title` for local-only season entries

## Test plan

- [ ] Open a TV show with named seasons (e.g. Dimension 20) — dropdown should show real season names
- [ ] Open a TV show with generic seasons (e.g. Breaking Bad) — dropdown should still show "Season 1", "Season 2", etc.
- [ ] Verify no 500 errors on season detail pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)