### PR TITLE
Add dedicated interactive Celery worker for user-triggered cache rebuilds

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -985,6 +985,10 @@ CELERY_TASK_ROUTES = {
     "Warm History Day Cache Coverage": {"priority": CELERY_TASK_PRIORITY_BACKGROUND},
     "Repair History Day Cache Coverage": {"priority": CELERY_TASK_PRIORITY_BACKGROUND},
     "Refresh Discover Profiles": {"priority": CELERY_TASK_PRIORITY_BACKGROUND},
+    # User-triggered cache rebuilds go to the dedicated interactive worker so they
+    # are never blocked behind long-running background tasks.
+    "app.tasks.refresh_statistics_cache_task": {"queue": "interactive"},
+    "app.tasks.refresh_history_cache_task": {"queue": "interactive"},
 }
 
 

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -21,7 +21,18 @@ stderr_logfile=/dev/stdout
 stderr_logfile_maxbytes=0
 
 [program:celery]
-command=sh -c 'if [ "${ENV_DEBUG:-False}" = "True" ]; then LOGLEVEL=DEBUG; else LOGLEVEL=INFO; fi; celery --app config worker --loglevel $LOGLEVEL --without-mingle --without-gossip'
+command=sh -c 'if [ "${ENV_DEBUG:-False}" = "True" ]; then LOGLEVEL=DEBUG; else LOGLEVEL=INFO; fi; celery --app config worker --queues celery --hostname=celery@%%h --loglevel $LOGLEVEL --without-mingle --without-gossip'
+user=abc
+stopasgroup=true
+stopwaitsecs=60
+priority=10
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stdout
+stderr_logfile_maxbytes=0
+
+[program:celery-interactive]
+command=sh -c 'if [ "${ENV_DEBUG:-False}" = "True" ]; then LOGLEVEL=DEBUG; else LOGLEVEL=INFO; fi; celery --app config worker --queues interactive --hostname=celery-interactive@%%h --loglevel $LOGLEVEL --without-mingle --without-gossip'
 user=abc
 stopasgroup=true
 stopwaitsecs=60


### PR DESCRIPTION
## Problem

All tasks share a single Celery worker (`concurrency=1`), so user-triggered cache refreshes — Statistics page ranges, History index rebuilds — queue behind long-running background tasks like nightly metadata backfills and reconcile jobs. The result is the UI spinning for minutes showing "Refreshing statistics in background…" even though the user is actively waiting.

## Solution

Add a second `celery-interactive` supervisord program that runs a dedicated Celery worker listening exclusively on the `interactive` queue. Route the two user-triggered tasks to that queue via `CELERY_TASK_ROUTES`:

- `app.tasks.refresh_statistics_cache_task`
- `app.tasks.refresh_history_cache_task`

The existing `celery` worker is pinned to the `celery` queue (explicit `--queues celery`) so background tasks continue unaffected. The interactive worker picks up cache rebuild tasks immediately regardless of background load.

## Changes

- **`supervisord.conf`** — pin existing worker to `--queues celery`, add `[program:celery-interactive]` on `--queues interactive`
- **`src/config/settings.py`** — add routes for the two interactive tasks in `CELERY_TASK_ROUTES`

## Test plan

- [ ] Build image, open Statistics page after a history entry is added — ranges should rebuild and complete within a few seconds rather than being delayed by background tasks
- [ ] Confirm `celery-interactive` worker appears in container logs on startup
- [ ] Confirm background tasks (backfills, reconciles) still run normally on the `celery` worker

🤖 Generated with [Claude Code](https://claude.com/claude-code)