### PR TITLE
Fix AttributeError: django.utils.timezone has no attribute 'utc' in podcast details

### DIFF
--- a/src/app/media_details_views.py
+++ b/src/app/media_details_views.py
@@ -415,7 +415,7 @@ def media_details(
 
             # Get all episodes for this show, ordered by published date (newest first)
             # Use Coalesce to handle None published dates (put them at the end)
-            from datetime import datetime
+            from datetime import datetime, timezone as dt_timezone
 
             from django.db.models import DateTimeField, Value
             from django.db.models.functions import Coalesce
@@ -423,7 +423,7 @@ def media_details(
             episodes = PodcastEpisode.objects.filter(show=show).annotate(
                 published_or_old=Coalesce(
                     "published",
-                    Value(datetime(1970, 1, 1, tzinfo=timezone.utc),
+                    Value(datetime(1970, 1, 1, tzinfo=dt_timezone.utc),
                           output_field=DateTimeField()),
                 ),
             ).order_by("-published_or_old", "-episode_number")


### PR DESCRIPTION
## Summary

- `media_details_views.py` line 426 used `timezone.utc` expecting Python's `datetime.timezone`, but `timezone` in that module's scope is `django.utils.timezone` (imported at the top of the file), which has no `.utc` attribute
- Fixed by importing `timezone as dt_timezone` from `datetime` alongside the existing `datetime` import inside the podcast details block, and using `dt_timezone.utc` for the epoch fallback value in the `Coalesce` annotation

## Traceback

```
AttributeError: module 'django.utils.timezone' has no attribute 'utc'
  File "/yamtrack/app/media_details_views.py", line 426, in media_details
    Value(datetime(1970, 1, 1, tzinfo=timezone.utc),
```

## Test plan

- [ ] Navigate to `/details/pocketcasts/podcast/<id>/<slug>` — should load without 500 error
- [ ] Confirm podcast episode list renders ordered by published date (newest first), with undated episodes at the end

🤖 Generated with [Claude Code](https://claude.com/claude-code)