### PR TITLE
Fix homepage card navigation broken by hx-boost inheriting scrollable row HTMX target

### DIFF
--- a/src/templates/app/components/media_card.html
+++ b/src/templates/app/components/media_card.html
@@ -24,8 +24,7 @@
                    loading="lazy">
             </div>
           {% else %}
-            <a hx-boost="true"
-               href="{% if media.album %}{{ media.album|music_album_url }}{% elif use_podcast_show|default:False and podcast_show %}{% url 'media_details' source='pocketcasts' media_type='podcast' media_id=podcast_show.podcast_uuid title=podcast_show.slug|default:podcast_show.title|default:podcast_show.podcast_uuid|slug %}{% elif public_view|default:False %}{{ item|media_url }}?public_view=1{% else %}{{ item|media_url }}{% endif %}">
+            <a href="{% if media.album %}{{ media.album|music_album_url }}{% elif use_podcast_show|default:False and podcast_show %}{% url 'media_details' source='pocketcasts' media_type='podcast' media_id=podcast_show.podcast_uuid title=podcast_show.slug|default:podcast_show.title|default:podcast_show.podcast_uuid|slug %}{% elif public_view|default:False %}{{ item|media_url }}?public_view=1{% else %}{{ item|media_url }}{% endif %}">
               <img alt="{% if use_podcast_show|default:False and podcast_show %}{{ podcast_show.title }}{% elif resolved_media_type == MediaTypes.SEASON.value %}{{ season_card_title_override|default:resolved_season_card_title }}{% else %}{{ resolved_item_title|default:title }}{% endif %}"
                    class="media-card-poster {% if hover_action_mode != 'discover' %}lazyload{% endif %} w-full {% if from_grid %}{% if resolved_media_type == 'podcast' or resolved_media_type == 'music' %}aspect-[1/1]{% else %}aspect-[2/3] aspect-2/3{% endif %}{% else %}h-48{% endif %} bg-[#3e454d] {% if image_override|default:item.image|default:IMG_NONE != IMG_NONE %}object-cover{% endif %}"
                    data-image-source="{{ image_source|default:'primary' }}"
@@ -215,7 +214,7 @@
               {# Darkening background layer #}
               <div class="absolute inset-0 bg-black/50 z-0"></div>
               
-              <a hx-boost="true" href="{% if use_podcast_show|default:False and podcast_show %}{% url 'media_details' source='pocketcasts' media_type='podcast' media_id=podcast_show.podcast_uuid title=podcast_show.slug|default:podcast_show.title|default:podcast_show.podcast_uuid|slug %}{% else %}{{ item|media_url }}{% endif %}" class="absolute inset-0 z-0"></a>
+              <a href="{% if use_podcast_show|default:False and podcast_show %}{% url 'media_details' source='pocketcasts' media_type='podcast' media_id=podcast_show.podcast_uuid title=podcast_show.slug|default:podcast_show.title|default:podcast_show.podcast_uuid|slug %}{% else %}{{ item|media_url }}{% endif %}" class="absolute inset-0 z-0"></a>
 
               <div class="relative z-10 flex items-center justify-center space-x-2.5"
                    {% if list_ordering_enabled|default:False %}
@@ -370,7 +369,6 @@
                     title="{% if resolved_media_type == MediaTypes.SEASON.value %}{{ season_card_title_override|default:resolved_season_card_title }}{% else %}{{ resolved_item_title|default:title }}{% endif %}">{% if resolved_media_type == MediaTypes.SEASON.value %}{{ season_card_title_override|default:resolved_season_card_title }}{% else %}{{ resolved_item_title|default:title }}{% endif %}</h3>
               {% else %}
                 <a href="{% if use_podcast_show|default:False and podcast_show %}{% url 'media_details' source='pocketcasts' media_type='podcast' media_id=podcast_show.podcast_uuid title=podcast_show.slug|default:podcast_show.title|default:podcast_show.podcast_uuid|slug %}{% elif public_view|default:False %}{{ item|media_url }}?public_view=1{% else %}{{ item|media_url }}{% endif %}"
-                   hx-boost="true"
                    class="media-card-title text-sm font-semibold text-white {% if not public_view|default:False %}hover:text-indigo-400{% endif %} transition duration-300 line-clamp-1 min-w-0"
                    title="{% if resolved_media_type == MediaTypes.SEASON.value %}{{ season_card_title_override|default:resolved_season_card_title }}{% else %}{{ resolved_item_title|default:title }}{% endif %}">{% if resolved_media_type == MediaTypes.SEASON.value %}{{ season_card_title_override|default:resolved_season_card_title }}{% else %}{{ resolved_item_title|default:title }}{% endif %}</a>
               {% endif %}


### PR DESCRIPTION
## Summary

- Media card navigation anchors (poster image, card overlay, title link) had `hx-boost="true"`, which caused HTMX to intercept clicks on the homepage
- The scrollable row parent div has `hx-target="this"` and `hx-swap="beforeend"` for its own infinite-scroll logic; child `hx-boost` links inherited both attributes
- When a card was clicked, HTMX fetched the detail page and swapped the response `beforeend` into the horizontal scroll row (invisible in overflow) instead of navigating the browser — the URL bar updated via `pushState` but no content loaded
- Fix: remove `hx-boost` from the three navigation anchors so the browser handles them as plain links with a full page load

Fixes #269 
## Test plan

- [ ] Click a show/season/movie card on the homepage — browser navigates to the correct detail page
- [ ] Click the poster image, the hover overlay, and the title link — all navigate correctly
- [ ] Scroll a home row to the end and verify more cards load (infinite-scroll unaffected)
- [ ] Verify recommend/discover mode cards still work (they use `hx-get` on the root div, not the nav anchors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)