### PR TITLE
fix(trakt): tolerate episodes existing under multiple library buckets

### DIFF
--- a/src/integrations/imports/trakt.py
+++ b/src/integrations/imports/trakt.py
@@ -369,9 +369,18 @@ class TraktImporter:
                         watched_at,
                     )
                     self.process_watched_episode(entry)
-            except Exception as e:
-                msg = f"Error processing history entry: {entry}"
-                raise MediaImportUnexpectedError(msg) from e
+            except MediaImportError:
+                # Fatal, importer-level problems (auth, etc.) must still abort.
+                raise
+            except Exception as e:  # noqa: BLE001
+                # A single malformed/unexpected entry should not abort the whole
+                # import; record it as a warning and continue with the rest.
+                logger.exception("Skipping Trakt history entry")
+                source_data = entry.get("show") or entry.get("movie") or {}
+                title = source_data.get("title", "Unknown title")
+                self.warnings.append(
+                    f"{title}: skipped a watch entry due to an unexpected error ({e}).",
+                )
 
     def _get_tmdb_id(self, entry_data):
         """Extract TMDB ID from entry data."""
@@ -418,7 +427,16 @@ class TraktImporter:
         season_number=None,
         episode_number=None,
     ):
-        """Get or create an item in the database."""
+        """Get or create an item in the database.
+
+        The same season/episode can legitimately exist under more than one
+        ``library_media_type`` bucket (e.g. grouped anime stored on TV rows, or
+        episodes auto-created when a season is marked complete). A plain
+        ``get_or_create`` keyed only on the identity fields therefore risks
+        ``MultipleObjectsReturned``. Reuse any existing matching item instead of
+        failing or creating a divergent duplicate, preferring the bucket this
+        importer would normally use.
+        """
         item_kwargs = {
             "media_id": tmdb_id,
             "source": Sources.TMDB.value,
@@ -431,17 +449,21 @@ class TraktImporter:
         if episode_number is not None:
             item_kwargs["episode_number"] = episode_number
 
-        defaults = {
-            **app.models.Item.title_fields_from_metadata(metadata),
-            "image": metadata["image"],
-        }
+        desired_bucket = metadata.get("library_media_type") or media_type
 
-        item, _ = app.models.Item.objects.get_or_create(
+        existing = list(app.models.Item.objects.filter(**item_kwargs))
+        if existing:
+            for item in existing:
+                if item.library_media_type == desired_bucket:
+                    return item
+            return existing[0]
+
+        return app.models.Item.objects.create(
             **item_kwargs,
-            defaults=defaults,
+            library_media_type=desired_bucket,
+            **app.models.Item.title_fields_from_metadata(metadata),
+            image=metadata["image"],
         )
-
-        return item
 
     def process_watched_movie(self, entry):
         """Process a single movie watch event."""

--- a/src/integrations/tests/imports/test_trakt.py
+++ b/src/integrations/tests/imports/test_trakt.py
@@ -1026,3 +1026,73 @@ class ImportTrakt(TestCase):
 
         tv_obj.refresh_from_db()
         self.assertEqual(tv_obj.status, Status.DROPPED.value)
+
+    def test_get_or_create_item_reuses_item_across_library_buckets(self):
+        """Episode existing under two library buckets must not crash the lookup.
+
+        Marking a season complete creates episode items inheriting the season's
+        ``library_media_type`` ('season'), while the importer creates them as
+        'episode'. Both rows are valid under the unique constraints, so a lookup
+        that ignores ``library_media_type`` previously raised
+        ``MultipleObjectsReturned``.
+        """
+        common = {
+            "media_id": "63404",
+            "source": Sources.TMDB.value,
+            "media_type": MediaTypes.EPISODE.value,
+            "season_number": 21,
+            "episode_number": 9,
+            "title": "Taskmaster",
+            "image": "img.jpg",
+        }
+        Item.objects.create(library_media_type=MediaTypes.EPISODE.value, **common)
+        Item.objects.create(library_media_type=MediaTypes.SEASON.value, **common)
+
+        trakt_importer = TraktImporter("testuser", self.user, "new")
+        metadata = {"title": "Taskmaster", "image": "img.jpg"}
+
+        result = trakt_importer._get_or_create_item(
+            MediaTypes.EPISODE.value,
+            "63404",
+            metadata,
+            season_number=21,
+            episode_number=9,
+        )
+
+        # Reuses the importer's preferred bucket, creates no duplicate.
+        self.assertEqual(result.library_media_type, MediaTypes.EPISODE.value)
+        self.assertEqual(
+            Item.objects.filter(
+                media_id="63404",
+                media_type=MediaTypes.EPISODE.value,
+                season_number=21,
+                episode_number=9,
+            ).count(),
+            2,
+        )
+
+    @patch("integrations.imports.trakt.TraktImporter._get_paginated_data")
+    def test_process_history_skips_unexpected_entry_error(self, mock_paginated):
+        """A single failing entry is recorded as a warning, not fatal."""
+        episode_entry = {
+            "type": "episode",
+            "episode": {"season": 21, "number": 9, "title": "Bad Episode"},
+            "show": {"title": "Taskmaster", "ids": {"tmdb": 63404}},
+            "watched_at": "2023-01-01T00:00:00.000Z",
+        }
+        mock_paginated.return_value = [episode_entry]
+
+        trakt_importer = TraktImporter("testuser", self.user, "new")
+
+        with patch.object(
+            trakt_importer,
+            "process_watched_episode",
+            side_effect=ValueError("boom"),
+        ):
+            # Must not raise.
+            trakt_importer.process_history()
+
+        self.assertTrue(
+            any("skipped a watch entry" in warning for warning in trakt_importer.warnings),
+            trakt_importer.warnings,
+        )


### PR DESCRIPTION
## Summary

The recurring Trakt import aborted for some users with:

```
app.models.item.Item.MultipleObjectsReturned: get() returned more than one Item -- it returned 2!
```

raised from `TraktImporter._get_or_create_item` while processing a perfectly
valid history entry (e.g. *Taskmaster* S21E9).

**Root cause.** Since `library_media_type` was folded into `Item`'s uniqueness
constraints (migration `0118`), the same `(media_id, source, media_type,
season_number, episode_number)` can legitimately exist under more than one
`library_media_type` bucket. The Trakt importer looked items up **without**
`library_media_type`, so when two such rows existed the implicit `get()` inside
`get_or_create` matched both and raised `MultipleObjectsReturned`, aborting the
whole import.

This PR makes the importer robust to that situation and prevents one bad entry
from killing an entire run:

- **`_get_or_create_item`** now reuses any existing matching item (preferring the
  importer's natural bucket) instead of failing or creating a divergent
  duplicate. It is intentionally **bucket-agnostic**: it cannot raise
  `MultipleObjectsReturned`, and it will not create duplicates regardless of
  which bucket a show's episodes were previously stored under.
- **`process_history`** now skips an individual malformed/unexpected entry with a
  warning and continues, instead of re-raising `MediaImportUnexpectedError` and
  aborting the run. Genuinely fatal `MediaImportError` (auth, etc.) still aborts.

No schema/migration changes.

### How the two-bucket data originated

Worth calling out because the fix here treats the symptom; the data that triggers
it is produced elsewhere.

`Season.get_episode_item` (`app/models/tv.py`) creates episode `Item`s with
`library_media_type = self.item.library_media_type` — i.e. it copies the
**season's** bucket onto the episode. For a normal (non-grouped) show the
season's bucket is `'season'`, so episodes created via this path are stamped
`('episode','season')`. This path runs whenever a **season or show is marked
complete**: `TV.save()` / `Season.save()` detect the status change and call
`get_remaining_eps()` → `get_episode_item()` to auto-fill the missing episodes.

Meanwhile the Trakt importer creates the same episodes as `('episode','episode')`
(its `save()` defaults `library_media_type` to `media_type`). Two producers, two
buckets, one collision when both touch the same episode.

Observed distribution on an affected DB (≈37k episode items):

| media_type | library_media_type | count | meaning |
|---|---|---|---|
| episode | episode | 23,929 | importer / default |
| episode | tv | 8,945 | watch/completion on a `tv`-bucketed season (legitimate grouping) |
| episode | season | **72** | **the artifact** — episodes wrongly bucketed as `season` |
| season | season | 1,719 | normal seasons |
| season | tv | 689 | grouped seasons |
| tv | tv | 574 | shows |

The `tv` buckets are an intended grouping pattern; `('episode','season')` is not
— no code path is *supposed* to bucket an episode as `season`.

### Potential follow-up fixes (not in this PR)

This PR deliberately stops at the safe, bucket-agnostic importer fix. The
underlying `get_episode_item` behavior and the stray rows are left for a separate
change because they touch shared model code and data:

- **Option A (this PR):** importer tolerates multiple buckets. Zero data risk;
  unblocks imports. Stray `('episode','season')` rows remain (harmless to import,
  but can skew stats / show as duplicate items).
- **Option B:** also fix `get_episode_item` so an episode's bucket is never the
  season's own type (use `'episode'` when the season bucket is `'season'`, else
  inherit the grouping bucket `'tv'`/`'anime'`), plus a guarded data migration to
  re-bucket/merge the existing stray rows (relinking `Episode`/history rows, not
  orphaning them). Requires choosing the canonical bucket.
- **Option C:** reconcile the whole bucket model — normal-show episodes currently
  exist as both `'episode'` (23,929) and `'tv'` (8,945); decide one canonical
  bucket for a show's chain and make every producer (importer,
  `get_episode_item`/`get_remaining_eps`, `save_views` propagation) agree, with a
  full migration. Larger, design-level decision.

Happy to follow up with Option B on its own branch if desired.

## Validation

```
cd src && python -m pytest integrations/tests/imports/test_trakt.py \
  -k "reuses_item_across_library_buckets or skips_unexpected_entry_error"
# 2 passed
```

- Added `test_get_or_create_item_reuses_item_across_library_buckets` (seeds the
  exact two-bucket data — `('episode','episode')` + `('episode','season')` — and
  asserts no crash and no duplicate) and
  `test_process_history_skips_unexpected_entry_error`. Both verified to **fail on
  the pre-fix code and pass with the fix** (red→green).
- Full `test_trakt.py`: the 2 new tests pass; 3 unrelated tests
  (`test_oauth_import_full_flow`, `test_dropped_show_status_on_first_import`,
  `test_dropped_show_updates_existing_tv`) fail **identically with and without
  this change** — pre-existing `StopIteration` mock drift, not a regression here.
- **Live end-to-end:** built this branch and ran a real Trakt import against a
  copy of an affected production DB (with the two conflicting rows present). The
  import processed *Taskmaster S21E9* — the previously fatal entry — and the task
  **succeeded**: `Imported 2 Movies, 64 Episodes, 2 TV Shows and 3 TV Seasons.`
  No `MultipleObjectsReturned`, and the episode now has an `Episode` row.

## Migration Sync Gate (Required for `dev` -> `latest` sync PRs)

N/A — this is a targeted bug fix, not a `dev` -> `latest` sync PR, and it
introduces no migrations.

## Notes

- Scoped intentionally to the importer; see "Potential follow-up fixes" for the
  `get_episode_item` root cause and the stray-row cleanup options.



---

## Follow-up

#281 builds on this PR. It fixes the **source** of the divergent buckets (`Season.get_episode_item` was copying the season's `library_media_type` onto episodes, producing the stray `('episode','season')` rows) and adds a data migration to clean up the existing rows. Merge this PR first, then #281.
