### PR TITLE
fix(tv): bucket episodes correctly + clean up stray ('episode','season') items (builds on #280)

### DIFF
--- a/src/app/migrations/0125_fix_episode_season_library_bucket.py
+++ b/src/app/migrations/0125_fix_episode_season_library_bucket.py
@@ -1,0 +1,73 @@
+"""Clean up stray ('episode','season') Item rows.
+
+Episodes were historically created with the season's own ``library_media_type``
+('season') when a season/show was marked complete (see Season.get_episode_item
+before the accompanying fix). The canonical bucket for a normal show's episode is
+'episode'. This migration re-buckets each stray row to 'episode', or merges it
+into the existing canonical 'episode' row (repointing dependents) when one
+already exists.
+"""
+
+from django.db import migrations, transaction
+from django.db.utils import IntegrityError
+
+
+def fix_episode_season_buckets(apps, schema_editor):
+    """Re-bucket or merge stray ('episode','season') items."""
+    del schema_editor
+    Item = apps.get_model("app", "Item")
+
+    strays = Item.objects.filter(media_type="episode", library_media_type="season")
+
+    for stray in strays.iterator():
+        canonical = (
+            Item.objects.filter(
+                media_id=stray.media_id,
+                source=stray.source,
+                media_type="episode",
+                library_media_type="episode",
+                season_number=stray.season_number,
+                episode_number=stray.episode_number,
+            )
+            .exclude(pk=stray.pk)
+            .first()
+        )
+
+        if canonical is None:
+            # No canonical row exists -> simply re-bucket in place. This cannot
+            # collide: the only constraint covering this row keys on
+            # library_media_type, and we just confirmed no 'episode' sibling.
+            stray.library_media_type = "episode"
+            stray.save(update_fields=["library_media_type"])
+            continue
+
+        # A canonical row exists -> repoint every dependent at it, then delete
+        # the stray. Most strays are orphans, so the loop is usually a no-op.
+        for relation in Item._meta.related_objects:
+            related_model = relation.related_model
+            field_name = relation.field.name
+            referencing = related_model.objects.filter(**{field_name: stray})
+            for obj in referencing.iterator():
+                try:
+                    with transaction.atomic():
+                        setattr(obj, field_name, canonical)
+                        obj.save(update_fields=[relation.field.attname])
+                except IntegrityError:
+                    # Canonical already has an equivalent row (unique clash);
+                    # the stray's duplicate is redundant.
+                    obj.delete()
+
+        stray.delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("app", "0124_podcastshow_source"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            fix_episode_season_buckets,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/src/app/models/tv.py
+++ b/src/app/models/tv.py
@@ -992,11 +992,23 @@ class Season(Media):
                     # If parsing fails, keep release_datetime as None
                     pass
 
+        # An episode's library bucket should mirror the show's grouping bucket
+        # (e.g. 'tv'/'anime' for grouped anime), never the season's own 'season'
+        # type. Copying the season's 'season' bucket onto episodes is what
+        # produced the stray ('episode','season') items, so fall back to
+        # 'episode' whenever the season is in its own (non-grouped) bucket.
+        season_bucket = self.item.library_media_type
+        episode_bucket = (
+            season_bucket
+            if season_bucket and season_bucket != MediaTypes.SEASON.value
+            else MediaTypes.EPISODE.value
+        )
+
         item, created = Item.objects.get_or_create(
             media_id=self.item.media_id,
             source=self.item.source,
             media_type=MediaTypes.EPISODE.value,
-            library_media_type=self.item.library_media_type,
+            library_media_type=episode_bucket,
             season_number=self.item.season_number,
             episode_number=normalized_episode_number,
             defaults={
@@ -1023,8 +1035,8 @@ class Season(Media):
                     setattr(item, field_name, value)
                     update_fields.append(field_name)
                     updated = True
-            if item.library_media_type != self.item.library_media_type:
-                item.library_media_type = self.item.library_media_type
+            if item.library_media_type != episode_bucket:
+                item.library_media_type = episode_bucket
                 update_fields.append("library_media_type")
                 updated = True
             if not item.runtime_minutes and runtime_minutes:

--- a/src/app/tests/models/test_episode_bucket.py
+++ b/src/app/tests/models/test_episode_bucket.py
@@ -1,0 +1,138 @@
+"""Tests for episode library-bucket derivation and the stray-row cleanup."""
+
+import importlib
+
+from django.apps import apps
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from app.models import TV, Episode, Item, MediaTypes, Season, Sources, Status
+
+SEASON_METADATA = {
+    "episodes": [{"episode_number": 1, "still_path": None}],
+    "_tvdb_episode_image_map": {},  # present -> skips the TVDB provider call
+}
+
+
+class GetEpisodeItemBucketTests(TestCase):
+    """Season.get_episode_item must never bucket an episode as 'season'."""
+
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(
+            username="test",
+            password="12345",
+        )
+
+    def _make_season(self, library_media_type):
+        item = Item.objects.create(
+            media_id="63404",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.SEASON.value,
+            library_media_type=library_media_type,
+            title="Taskmaster",
+            image="http://example.com/i.jpg",
+            season_number=21,
+        )
+        return Season.objects.create(
+            item=item,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+        )
+
+    def test_normal_season_creates_episode_bucket(self):
+        """A 'season'-bucketed season yields 'episode'-bucketed episodes."""
+        season = self._make_season(MediaTypes.SEASON.value)
+        item = season.get_episode_item(1, SEASON_METADATA)
+        self.assertEqual(item.library_media_type, MediaTypes.EPISODE.value)
+
+    def test_grouped_season_keeps_grouping_bucket(self):
+        """A grouped ('tv') season keeps episodes in the 'tv' bucket."""
+        season = self._make_season(MediaTypes.TV.value)
+        item = season.get_episode_item(1, SEASON_METADATA)
+        self.assertEqual(item.library_media_type, MediaTypes.TV.value)
+
+
+class EpisodeSeasonBucketMigrationTests(TestCase):
+    """The 0125 data migration re-buckets or merges stray rows."""
+
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(
+            username="test",
+            password="12345",
+        )
+        self.migration = importlib.import_module(
+            "app.migrations.0125_fix_episode_season_library_bucket",
+        )
+
+    def _stray(self, episode_number):
+        return Item.objects.create(
+            media_id="63404",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            library_media_type=MediaTypes.SEASON.value,
+            title="Taskmaster",
+            image="http://example.com/i.jpg",
+            season_number=21,
+            episode_number=episode_number,
+        )
+
+    def test_rebuckets_stray_without_canonical(self):
+        """No canonical sibling -> stray is re-bucketed in place to 'episode'."""
+        stray = self._stray(1)
+        self.migration.fix_episode_season_buckets(apps, None)
+        stray.refresh_from_db()
+        self.assertEqual(stray.library_media_type, MediaTypes.EPISODE.value)
+
+    def test_merges_stray_into_canonical(self):
+        """Canonical sibling exists -> dependents move to it and stray is gone."""
+        canonical = Item.objects.create(
+            media_id="63404",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            library_media_type=MediaTypes.EPISODE.value,
+            title="Taskmaster",
+            image="http://example.com/i.jpg",
+            season_number=21,
+            episode_number=2,
+        )
+        stray = self._stray(2)
+
+        season_item = Item.objects.create(
+            media_id="63404",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.SEASON.value,
+            library_media_type=MediaTypes.SEASON.value,
+            title="Taskmaster",
+            image="http://example.com/i.jpg",
+            season_number=21,
+        )
+        season = Season.objects.create(
+            item=season_item,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+        )
+        episode = Episode.objects.create(item=stray, related_season=season)
+
+        self.migration.fix_episode_season_buckets(apps, None)
+
+        self.assertFalse(Item.objects.filter(pk=stray.pk).exists())
+        episode.refresh_from_db()
+        self.assertEqual(episode.item_id, canonical.pk)
+
+    def test_orphan_stray_with_canonical_is_deleted(self):
+        """An orphan stray with a canonical sibling is simply removed."""
+        Item.objects.create(
+            media_id="63404",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            library_media_type=MediaTypes.EPISODE.value,
+            title="Taskmaster",
+            image="http://example.com/i.jpg",
+            season_number=21,
+            episode_number=9,
+        )
+        stray = self._stray(9)
+
+        self.migration.fix_episode_season_buckets(apps, None)
+
+        self.assertFalse(Item.objects.filter(pk=stray.pk).exists())

--- a/src/integrations/imports/trakt.py
+++ b/src/integrations/imports/trakt.py
@@ -369,9 +369,18 @@ class TraktImporter:
                         watched_at,
                     )
                     self.process_watched_episode(entry)
-            except Exception as e:
-                msg = f"Error processing history entry: {entry}"
-                raise MediaImportUnexpectedError(msg) from e
+            except MediaImportError:
+                # Fatal, importer-level problems (auth, etc.) must still abort.
+                raise
+            except Exception as e:  # noqa: BLE001
+                # A single malformed/unexpected entry should not abort the whole
+                # import; record it as a warning and continue with the rest.
+                logger.exception("Skipping Trakt history entry")
+                source_data = entry.get("show") or entry.get("movie") or {}
+                title = source_data.get("title", "Unknown title")
+                self.warnings.append(
+                    f"{title}: skipped a watch entry due to an unexpected error ({e}).",
+                )
 
     def _get_tmdb_id(self, entry_data):
         """Extract TMDB ID from entry data."""
@@ -418,7 +427,16 @@ class TraktImporter:
         season_number=None,
         episode_number=None,
     ):
-        """Get or create an item in the database."""
+        """Get or create an item in the database.
+
+        The same season/episode can legitimately exist under more than one
+        ``library_media_type`` bucket (e.g. grouped anime stored on TV rows, or
+        episodes auto-created when a season is marked complete). A plain
+        ``get_or_create`` keyed only on the identity fields therefore risks
+        ``MultipleObjectsReturned``. Reuse any existing matching item instead of
+        failing or creating a divergent duplicate, preferring the bucket this
+        importer would normally use.
+        """
         item_kwargs = {
             "media_id": tmdb_id,
             "source": Sources.TMDB.value,
@@ -431,17 +449,21 @@ class TraktImporter:
         if episode_number is not None:
             item_kwargs["episode_number"] = episode_number
 
-        defaults = {
-            **app.models.Item.title_fields_from_metadata(metadata),
-            "image": metadata["image"],
-        }
+        desired_bucket = metadata.get("library_media_type") or media_type
 
-        item, _ = app.models.Item.objects.get_or_create(
+        existing = list(app.models.Item.objects.filter(**item_kwargs))
+        if existing:
+            for item in existing:
+                if item.library_media_type == desired_bucket:
+                    return item
+            return existing[0]
+
+        return app.models.Item.objects.create(
             **item_kwargs,
-            defaults=defaults,
+            library_media_type=desired_bucket,
+            **app.models.Item.title_fields_from_metadata(metadata),
+            image=metadata["image"],
         )
-
-        return item
 
     def process_watched_movie(self, entry):
         """Process a single movie watch event."""

--- a/src/integrations/tests/imports/test_trakt.py
+++ b/src/integrations/tests/imports/test_trakt.py
@@ -1026,3 +1026,73 @@ class ImportTrakt(TestCase):
 
         tv_obj.refresh_from_db()
         self.assertEqual(tv_obj.status, Status.DROPPED.value)
+
+    def test_get_or_create_item_reuses_item_across_library_buckets(self):
+        """Episode existing under two library buckets must not crash the lookup.
+
+        Marking a season complete creates episode items inheriting the season's
+        ``library_media_type`` ('season'), while the importer creates them as
+        'episode'. Both rows are valid under the unique constraints, so a lookup
+        that ignores ``library_media_type`` previously raised
+        ``MultipleObjectsReturned``.
+        """
+        common = {
+            "media_id": "63404",
+            "source": Sources.TMDB.value,
+            "media_type": MediaTypes.EPISODE.value,
+            "season_number": 21,
+            "episode_number": 9,
+            "title": "Taskmaster",
+            "image": "img.jpg",
+        }
+        Item.objects.create(library_media_type=MediaTypes.EPISODE.value, **common)
+        Item.objects.create(library_media_type=MediaTypes.SEASON.value, **common)
+
+        trakt_importer = TraktImporter("testuser", self.user, "new")
+        metadata = {"title": "Taskmaster", "image": "img.jpg"}
+
+        result = trakt_importer._get_or_create_item(
+            MediaTypes.EPISODE.value,
+            "63404",
+            metadata,
+            season_number=21,
+            episode_number=9,
+        )
+
+        # Reuses the importer's preferred bucket, creates no duplicate.
+        self.assertEqual(result.library_media_type, MediaTypes.EPISODE.value)
+        self.assertEqual(
+            Item.objects.filter(
+                media_id="63404",
+                media_type=MediaTypes.EPISODE.value,
+                season_number=21,
+                episode_number=9,
+            ).count(),
+            2,
+        )
+
+    @patch("integrations.imports.trakt.TraktImporter._get_paginated_data")
+    def test_process_history_skips_unexpected_entry_error(self, mock_paginated):
+        """A single failing entry is recorded as a warning, not fatal."""
+        episode_entry = {
+            "type": "episode",
+            "episode": {"season": 21, "number": 9, "title": "Bad Episode"},
+            "show": {"title": "Taskmaster", "ids": {"tmdb": 63404}},
+            "watched_at": "2023-01-01T00:00:00.000Z",
+        }
+        mock_paginated.return_value = [episode_entry]
+
+        trakt_importer = TraktImporter("testuser", self.user, "new")
+
+        with patch.object(
+            trakt_importer,
+            "process_watched_episode",
+            side_effect=ValueError("boom"),
+        ):
+            # Must not raise.
+            trakt_importer.process_history()
+
+        self.assertTrue(
+            any("skipped a watch entry" in warning for warning in trakt_importer.warnings),
+            trakt_importer.warnings,
+        )


### PR DESCRIPTION
## Summary

**Builds on #280 — please review/merge that first.** #280 made the Trakt importer
*tolerate* episodes that exist under multiple `library_media_type` buckets (stops
the crash). This PR fixes the **source** of the bad data and cleans up the
existing rows.

> 🔗 **Stacked PR.** This branch (`fix/episode-bucket-source-and-cleanup`) is
> based on #280's branch (`fix/episode-library-media-type-bucket`), so the diff
> shown here currently includes #280's commit too. Once #280 merges, this reduces
> to the two commits described below. Refs #280.

> ⚠️ **CRITICAL — reviewer attention requested on migration `0125`.**
> The data migration **mutates and deletes `Item` rows and repoints their
> dependents**. It was only validated end-to-end against **one real dataset (the
> reporter's)**, plus unit tests. Other libraries may have data shapes this
> hasn't seen — e.g. an `('episode','season')` row with multiple kinds of
> dependents (calendar `Event`s, custom-list entries), grouped-anime
> interactions, or unique-constraint collisions on relations other than
> `Episode`. Please scrutinize the merge/repoint path specifically, and
> **users should have a DB backup before upgrading** (the migration's reverse is
> a no-op — deletions cannot be undone).

### Root cause being fixed here

`Season.get_episode_item` (`app/models/tv.py`) created episode `Item`s with
`library_media_type = self.item.library_media_type` — i.e. it copied the
**season's** bucket onto the episode. For a normal (non-grouped) show the
season's bucket is `'season'`, so episodes created via this path were stamped
`('episode','season')`. This path runs whenever a **season or show is marked
complete** (`TV.save()` / `Season.save()` → `get_remaining_eps()` →
`get_episode_item()` auto-fills the remaining episodes).

The Trakt importer creates the same episodes as `('episode','episode')`, so the
two producers diverged and collided — which is what #280 defends against. On the
affected DB this produced **72** stray `('episode','season')` rows (vs. the
legitimate `('episode','tv')` grouping pattern).

### Changes

1. **`get_episode_item` now derives the episode bucket** instead of copying the
   season's: it mirrors the show's grouping bucket (`'tv'`/`'anime'`) when
   grouped, and falls back to `'episode'` when the season is in its own
   (non-grouped) `'season'` bucket. It can no longer stamp `'season'` on an
   episode.

2. **Data migration `0125`** cleans up existing stray rows: each
   `('episode','season')` item is re-bucketed to `'episode'`, or — when a
   canonical `('episode','episode')` row already exists — its dependents are
   repointed to the canonical row and the stray is deleted. The merge is
   collision-safe in the cases tested (`Episode` excludes `item` from history and
   has no item-unique constraint; unique clashes on other relations fall back to
   deleting the redundant duplicate). Reverse is a no-op. See the critical note
   above — this is the part most needing review.

No schema changes (the migration is data-only `RunPython`).

## Validation

```
cd src && python -m pytest app/tests/models/test_episode_bucket.py
# 5 passed
```

- New `app/tests/models/test_episode_bucket.py` covers: normal season →
  `'episode'` bucket; grouped (`'tv'`) season → `'tv'` bucket; and the migration's
  re-bucket, merge (dependent `Episode` repointed), and orphan-delete paths.
  `test_normal_season_creates_episode_bucket` verified to **fail before / pass
  after** the `get_episode_item` change.
- `app/tests/models/test_season.py`: **8 failed / 18 passed** with this change vs.
  **9 failed / 17 passed** on the base — i.e. **no new regressions, and one
  previously-failing test now passes**
  (`test_get_episode_item_updates_existing_item_with_episode_title`). The
  remaining 8 failures are pre-existing and unrelated.
- **Live:** validated end-to-end in #280 against a copy of the affected
  production DB (full Trakt import succeeded through the previously-fatal
  *Taskmaster* S21E9 entry). The migration cleanup itself was exercised on that
  same single dataset — hence the critical note above.

## Migration Sync Gate (Required for `dev` -> `latest` sync PRs)

N/A — targeted bug fix, not a `dev` -> `latest` sync PR. Migration `0125` is
data-only (no schema change). Note: `makemigrations --check` reports pre-existing
drift on unrelated fields (`item.source`, `itemproviderlink.provider`,
`person.source`, `studio.source`) that is present on the base branch and not
introduced here.

## Notes

- Builds on and must merge after #280. Refs #280.
