### PR TITLE
Fix NameError in detail secondary fragment when syncing reading genres

### DIFF
--- a/src/app/media_details_views.py
+++ b/src/app/media_details_views.py
@@ -45,6 +45,7 @@ from app.detail_builders import (
     _build_trakt_popularity_context,
 )
 from app.log_safety import exception_summary
+from app.media_list_views import _collect_reading_activity_day_keys
 from app.metadata_sync_views import _build_flat_anime_episode_preview
 from app.models import (
     TV,

--- a/src/app/tests/views/test_media_details.py
+++ b/src/app/tests/views/test_media_details.py
@@ -311,6 +311,80 @@ class MediaDetailsViewTests(TestCase):
             lookup_policy="cached_only",
         )
 
+    @patch("integrations.tasks.fetch_collection_metadata_for_item.delay")
+    @patch("app.views.credits.sync_item_credits_from_metadata")
+    @patch("app.views.metadata_utils.apply_item_metadata", return_value=[])
+    @patch("app.providers.services.get_media_metadata")
+    def test_media_details_secondary_fragment_syncs_reading_genres_without_error(
+        self,
+        mock_get_metadata,
+        _mock_apply_item_metadata,
+        _mock_sync_credits,
+        _mock_fetch_delay,
+    ):
+        """Regression: syncing stale genres on a tracked reading item must not 500.
+
+        When a book/comic/manga's stored genres differ from the freshly
+        resolved metadata, the secondary fragment updates the item and
+        invalidates the affected reading-activity statistics days. That path
+        calls ``_collect_reading_activity_day_keys``, which previously raised
+        ``NameError`` because it was never imported into this module, returning
+        a 500 that left the lazy fragment's skeleton loaders spinning forever.
+        """
+        mock_get_metadata.return_value = {
+            "media_id": "119735",
+            "title": "Test Manga",
+            "media_type": MediaTypes.MANGA.value,
+            "source": Sources.MAL.value,
+            "source_url": "https://myanimelist.net/manga/119735",
+            "image": "http://example.com/image.jpg",
+            "synopsis": "Test synopsis",
+            "max_progress": 145,
+            # Genres deliberately differ from the stored item below so the
+            # genre-sync branch fires and marks genres as updated.
+            "genres": ["Comedy", "Romance"],
+            "details": {},
+            "related": {},
+            "cast": [],
+            "crew": [],
+            "studios_full": [],
+        }
+        item = Item.objects.create(
+            media_id="119735",
+            source=Sources.MAL.value,
+            media_type=MediaTypes.MANGA.value,
+            title="Test Manga",
+            image="http://example.com/image.jpg",
+            genres=["Drama"],
+        )
+        Manga.objects.create(
+            item=item,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+            progress=10,
+            start_date=datetime(2026, 3, 1, 12, 0, tzinfo=UTC),
+            end_date=datetime(2026, 3, 20, 12, 0, tzinfo=UTC),
+        )
+
+        response = self.client.get(
+            reverse(
+                "media_details",
+                kwargs={
+                    "source": Sources.MAL.value,
+                    "media_type": MediaTypes.MANGA.value,
+                    "media_id": item.media_id,
+                    "title": "test-manga",
+                },
+            ),
+            {"fragment": "secondary"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "app/components/detail_secondary_content.html")
+        # The genre-sync branch ran and persisted the resolved genres.
+        item.refresh_from_db()
+        self.assertEqual(item.genres, ["Comedy", "Romance"])
+
     @patch("app.providers.services.session.get")
     def test_media_details_renders_service_unavailable_page_when_tmdb_is_unreachable(
         self,


### PR DESCRIPTION
## Summary

The deferred secondary fragment of a book/comic/manga details page calls `_collect_reading_activity_day_keys()` to invalidate the affected statistics days whenever it syncs stale stored genres to freshly resolved metadata. That helper lives in `media_list_views` but was never imported into `media_details_views`, so the branch raised `NameError` and returned a 500.

Because the fragment is loaded via htmx with `hx-swap="outerHTML"` (which only swaps on a 2xx), the 500 left the skeleton loaders spinning forever for any logged-in user whose stored genres differed from the provider's. Anonymous views were unaffected because the genre-sync branch is gated on an authenticated, tracked instance.

Fix: add the missing top-level import (matching this module's existing cross-view import style, e.g. `metadata_sync_views`), plus a regression test that drives the genre-sync path and asserts the secondary fragment returns 200.

## Validation

- `cd src && SECRET=test python manage.py test app.tests.views.test_media_details.MediaDetailsViewTests.test_media_details_secondary_fragment_syncs_reading_genres_without_error` — passes with the fix; fails with the exact `NameError` (500) when the import is reverted.
- `python manage.py check` — no issues (confirms the top-level import introduces no circular import).
- `ruff check` on the changed lines — no new violations; import ordering correct.

## Migration Sync Gate (Required for `dev` -> `latest` sync PRs)

N/A — not a dev→latest sync PR. No models or migrations touched (one import + one test).

## Notes

- Repro: open a tracked manga details page as a logged-in user when the stored genres differ from the provider metadata; the lower half stays stuck on skeleton loaders.
