### PR TITLE
fix: navigate to episode page from Home "Next ep" button

### DIFF
--- a/src/templates/app/components/media_card.html
+++ b/src/templates/app/components/media_card.html
@@ -184,8 +184,13 @@
                     {% if ep_status == Status.IN_PROGRESS.value %}
                       {% next_episode_url item media as next_ep_href %}
                       {% if next_ep_href %}
+                        {# No hx-boost: this link lives inside the home row's
+                           hx-target="this"/hx-swap="beforeend" scroll container,
+                           and a boosted link would inherit those attributes and
+                           swap the episode page into the row instead of
+                           navigating. A plain link navigates normally. #}
                         <a href="{{ next_ep_href }}"
-                           hx-boost="true"
+                           hx-disable
                            class="absolute top-2 right-2 z-20 bg-gray-900/90 hover:bg-indigo-600 text-white text-[11px] font-medium px-2 py-1 rounded-md flex items-center gap-0.5 shadow-md transition-colors"
                            title="Jump to next episode">
                           {% include "app/icons/chevron-right.svg" with classes="w-3 h-3" %}


### PR DESCRIPTION
## Problem

Clicking the **"Next ep"** quick-link on a Home media card didn't open the episode details page. Instead the URL updated to the episode path while every Home row except the clicked one vanished — the episode page got swapped *into* the row.

## Cause

The "Next ep" link carried `hx-boost="true"`. The card sits inside the home row's horizontal scroll container, which declares `hx-target="this"` and `hx-swap="beforeend"` for lazy pagination. htmx **inherits** `hx-target`/`hx-swap` from ancestors, so the boosted link appended the fetched episode page into the TV row instead of navigating.

## Fix

Replace `hx-boost="true"` with `hx-disable` so the link performs a plain full navigation, matching the sibling full-card link. Added a comment documenting the inheritance trap so boosting isn't reintroduced.

## Verification

Ran the app locally against a copy of a real library and clicked the "Next ep" pill on an in-progress show — it now navigates to the episode details page as expected.