### PR TITLE
fix(episode-page): update Mark Watched & rating in place, stop leaking template comments

### DIFF
--- a/src/app/save_views.py
+++ b/src/app/save_views.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.shortcuts import redirect, render
+from django.template.loader import render_to_string
 from django.views.decorators.http import require_POST
 
 from app import cache_utils, helpers
@@ -340,11 +341,102 @@ def media_delete(request):
     return redirect_response
 
 
+def _write_episode_save_oob(
+    response,
+    request,
+    *,
+    episode,
+    related_season,
+    media_id,
+    source,
+    season_number,
+    episode_number,
+    next_path,
+):
+    """Write the OOB fragments for an episode watch/drop response.
+
+    The season-details episode list and the standalone episode page render
+    different markup (small round button + history line + season-progress spans
+    vs. a hero pill button + an always-present rating-chip slot), so each needs
+    its own OOB targets. We detect the standalone episode page from the `next`
+    path and emit the matching variant; sending the wrong one just no-ops since
+    HTMX silently drops OOB swaps with no matching element.
+    """
+    parsed_next = urlparse(next_path).path
+    path_parts = [segment for segment in parsed_next.split("/") if segment]
+    is_episode_page = (
+        len(path_parts) >= 2
+        and path_parts[0] == "details"
+        and "episode" in path_parts
+    )
+
+    if is_episode_page:
+        response.write(
+            render_to_string(
+                "app/components/detail_episode_hero_track_button.html",
+                {
+                    "episode": episode,
+                    "source": source,
+                    "media_id": media_id,
+                    "season_number": season_number,
+                    "episode_number": episode_number,
+                    "track_button_oob": True,
+                },
+                request=request,
+            ),
+        )
+        response.write(
+            render_to_string(
+                "app/components/detail_episode_rating_chip.html",
+                {
+                    "episode": episode,
+                    "current_instance": related_season,
+                    "user": request.user,
+                    "source": source,
+                    "media_id": media_id,
+                    "season_number": season_number,
+                    "episode_number": episode_number,
+                    "public_view": False,
+                    "rating_chip_oob": True,
+                },
+                request=request,
+            ),
+        )
+        # Season-progress spans only exist on the season page — nothing to target here.
+        return
+
+    response.write(
+        render_to_string(
+            "app/components/detail_episode_track_button.html",
+            {
+                "episode": episode,
+                "track_button_oob": True,
+            },
+            request=request,
+        ),
+    )
+    response.write(
+        render_to_string(
+            "app/components/detail_episode_history_line.html",
+            {
+                "episode": episode,
+                "user": request.user,
+                "history_oob": True,
+            },
+            request=request,
+        ),
+    )
+    response.write(
+        f'<span id="season-progress-mobile-{related_season.id}" hx-swap-oob="true" class="text-sm font-medium text-gray-400">Progress: {related_season.completed_episode_count}{f"/{related_season.max_progress}" if related_season.max_progress else ""}</span>',
+    )
+    response.write(
+        f'<span id="season-progress-desktop-{related_season.id}" hx-swap-oob="true" class="text-sm font-medium text-gray-400">Progress: {related_season.completed_episode_count}{f"/{related_season.max_progress}" if related_season.max_progress else ""}</span>',
+    )
+
+
 @require_POST
 def episode_save(request):
     """Handle the creation, deletion, and updating of episodes for a season."""
-    from django.template.loader import render_to_string
-
     media_id = request.POST["media_id"]
     season_number = int(request.POST["season_number"])
     episode_number = int(request.POST["episode_number"])
@@ -448,32 +540,16 @@ def episode_save(request):
         ).select_related("item").first()
 
         response = HttpResponse()
-        response.write(
-            render_to_string(
-                "app/components/detail_episode_track_button.html",
-                {
-                    "episode": episode,
-                    "track_button_oob": True,
-                },
-                request=request,
-            ),
-        )
-        response.write(
-            render_to_string(
-                "app/components/detail_episode_history_line.html",
-                {
-                    "episode": episode,
-                    "user": request.user,
-                    "history_oob": True,
-                },
-                request=request,
-            ),
-        )
-        response.write(
-            f'<span id="season-progress-mobile-{related_season.id}" hx-swap-oob="true" class="text-sm font-medium text-gray-400">Progress: {related_season.completed_episode_count}{f"/{related_season.max_progress}" if related_season.max_progress else ""}</span>',
-        )
-        response.write(
-            f'<span id="season-progress-desktop-{related_season.id}" hx-swap-oob="true" class="text-sm font-medium text-gray-400">Progress: {related_season.completed_episode_count}{f"/{related_season.max_progress}" if related_season.max_progress else ""}</span>',
+        _write_episode_save_oob(
+            response,
+            request,
+            episode=episode,
+            related_season=related_season,
+            media_id=media_id,
+            source=source,
+            season_number=season_number,
+            episode_number=episode_number,
+            next_path=next_path,
         )
         response["HX-Trigger"] = json.dumps(
             {
@@ -495,8 +571,6 @@ def episode_save(request):
 @require_POST
 def episode_drop(request):
     """Mark an episode as dropped — advances progress without adding to watch history."""
-    from django.template.loader import render_to_string
-
     media_id = request.POST["media_id"]
     season_number = int(request.POST["season_number"])
     episode_number = int(request.POST["episode_number"])
@@ -601,32 +675,16 @@ def episode_drop(request):
         ).select_related("item").first()
 
         response = HttpResponse()
-        response.write(
-            render_to_string(
-                "app/components/detail_episode_track_button.html",
-                {
-                    "episode": episode,
-                    "track_button_oob": True,
-                },
-                request=request,
-            ),
-        )
-        response.write(
-            render_to_string(
-                "app/components/detail_episode_history_line.html",
-                {
-                    "episode": episode,
-                    "user": request.user,
-                    "history_oob": True,
-                },
-                request=request,
-            ),
-        )
-        response.write(
-            f'<span id="season-progress-mobile-{related_season.id}" hx-swap-oob="true" class="text-sm font-medium text-gray-400">Progress: {related_season.completed_episode_count}{f"/{related_season.max_progress}" if related_season.max_progress else ""}</span>',
-        )
-        response.write(
-            f'<span id="season-progress-desktop-{related_season.id}" hx-swap-oob="true" class="text-sm font-medium text-gray-400">Progress: {related_season.completed_episode_count}{f"/{related_season.max_progress}" if related_season.max_progress else ""}</span>',
+        _write_episode_save_oob(
+            response,
+            request,
+            episode=episode,
+            related_season=related_season,
+            media_id=media_id,
+            source=source,
+            season_number=season_number,
+            episode_number=episode_number,
+            next_path=next_path,
         )
         response["HX-Trigger"] = json.dumps(
             {

--- a/src/templates/app/components/detail_episode_hero_track_button.html
+++ b/src/templates/app/components/detail_episode_hero_track_button.html
@@ -1,12 +1,6 @@
 {% load app_tags %}
 
-{# Hero variant of the episode track button used on the standalone episode page.
-
-   The wrapper id is keyed on the stable source/media/season/episode identifiers
-   (NOT episode.item.id) so that episode_save can target it with an OOB swap even
-   on the very first watch, when no episode Item exists yet. The enclosing
-   x-data="{ trackOpen: false }" scope and the track modal live in the parent
-   template, so only this button is replaced on swap. #}
+{# Hero variant of the episode track button used on the standalone episode page. The wrapper id is keyed on the stable source/media/season/episode identifiers (NOT episode.item.id) so that episode_save can target it with an OOB swap even on the very first watch, when no episode Item exists yet. The enclosing x-data="{ trackOpen: false }" scope and the track modal live in the parent template, so only this button is replaced on swap. #}
 <div id="episode-track-button-{{ source }}-{{ media_id }}-{{ season_number }}-{{ episode_number }}"
      {% if track_button_oob %}hx-swap-oob="true"{% endif %}>
   <button type="button"

--- a/src/templates/app/components/detail_episode_hero_track_button.html
+++ b/src/templates/app/components/detail_episode_hero_track_button.html
@@ -1,0 +1,23 @@
+{% load app_tags %}
+
+{# Hero variant of the episode track button used on the standalone episode page.
+
+   The wrapper id is keyed on the stable source/media/season/episode identifiers
+   (NOT episode.item.id) so that episode_save can target it with an OOB swap even
+   on the very first watch, when no episode Item exists yet. The enclosing
+   x-data="{ trackOpen: false }" scope and the track modal live in the parent
+   template, so only this button is replaced on swap. #}
+<div id="episode-track-button-{{ source }}-{{ media_id }}-{{ season_number }}-{{ episode_number }}"
+     {% if track_button_oob %}hx-swap-oob="true"{% endif %}>
+  <button type="button"
+          @click="trackOpen = true"
+          class="inline-flex w-full items-center justify-center gap-3 rounded-xl px-5 py-3 text-white shadow-sm transition duration-300 cursor-pointer sm:w-auto {% if episode.history %}bg-indigo-600 hover:bg-indigo-700{% else %}bg-gray-600 hover:bg-gray-700{% endif %}">
+    {% if episode.history %}
+      {% include "app/icons/eye.svg" with classes="w-5 h-5 shrink-0" %}
+      <span class="font-medium">Watched</span>
+    {% else %}
+      {% include "app/icons/eye-closed.svg" with classes="w-5 h-5 shrink-0" %}
+      <span class="font-medium">Mark Watched</span>
+    {% endif %}
+  </button>
+</div>

--- a/src/templates/app/components/detail_episode_rating_chip.html
+++ b/src/templates/app/components/detail_episode_rating_chip.html
@@ -1,13 +1,7 @@
 {% load app_tags %}
 {% load user_tags %}
 
-{# Always-present rating-chip slot for the standalone episode page.
-
-   The wrapper div is rendered even when the user has no watch history yet (it is
-   simply empty), so episode_save can OOB-swap the populated chip in on the first
-   watch without a page reload. `class="contents"` keeps the wrapper out of the
-   flex layout. The inner chip is only rendered once history + a season instance
-   exist. #}
+{# Always-present rating-chip slot for the standalone episode page. The wrapper div is rendered even when the user has no watch history yet (it is simply empty), so episode_save can OOB-swap the populated chip in on the first watch without a page reload. `class="contents"` keeps the wrapper out of the flex layout. The inner chip is only rendered once history + a season instance exist. #}
 <div id="episode-rating-chip-{{ source }}-{{ media_id }}-{{ season_number }}-{{ episode_number }}"
      {% if rating_chip_oob %}hx-swap-oob="true"{% endif %}
      class="contents">
@@ -30,11 +24,13 @@
           {% include "app/icons/star.svg" with classes="h-3.5 w-3.5 text-yellow-400 fill-yellow-400 sm:h-4 sm:w-4" %}
         </span>
         <span class="inline-flex items-center gap-1 sm:gap-2">
-          <span class="text-[12px] font-semibold text-white sm:text-sm {% if ep_score is None %}hidden{% endif %}"
-                :class="rating ? '' : 'hidden'"
+          <span class="text-[12px] font-semibold text-white sm:text-sm"
+                x-cloak
+                x-show="rating"
                 x-text="formatRating(rating)">{% if ep_score is not None %}{{ ep_score|score_display:user }}{% endif %}</span>
-          <span class="text-[12px] text-gray-500 sm:text-sm {% if ep_score is None %}hidden{% endif %}"
-                :class="rating ? '' : 'hidden'">|</span>
+          <span class="text-[12px] text-gray-500 sm:text-sm"
+                x-cloak
+                x-show="rating">|</span>
           <span class="text-[12px] font-medium text-gray-200 sm:text-sm"
                 x-text="rating ? 'Edit rating' : 'Add rating'">{% if ep_score is not None %}Edit rating{% else %}Add rating{% endif %}</span>
         </span>

--- a/src/templates/app/components/detail_episode_rating_chip.html
+++ b/src/templates/app/components/detail_episode_rating_chip.html
@@ -1,0 +1,70 @@
+{% load app_tags %}
+{% load user_tags %}
+
+{# Always-present rating-chip slot for the standalone episode page.
+
+   The wrapper div is rendered even when the user has no watch history yet (it is
+   simply empty), so episode_save can OOB-swap the populated chip in on the first
+   watch without a page reload. `class="contents"` keeps the wrapper out of the
+   flex layout. The inner chip is only rendered once history + a season instance
+   exist. #}
+<div id="episode-rating-chip-{{ source }}-{{ media_id }}-{{ season_number }}-{{ episode_number }}"
+     {% if rating_chip_oob %}hx-swap-oob="true"{% endif %}
+     class="contents">
+  {% if not public_view and episode and episode.history and current_instance %}
+    {% with ep_score=episode.history.0.score %}
+    <div x-data="{
+      showRatingPopup: false,
+      rating: {% if ep_score is not None %}{{ ep_score|score_display:user }}{% else %}null{% endif %},
+      ratingScaleMax: {{ user|rating_scale_max }},
+      hoverRating: null,
+      isHovering: false,
+      formatRating(v) { if (v === null || v === undefined || v === '') return ''; return this.ratingScaleMax === 5 ? String(v) + '/5' : String(v); }
+    }"
+         class="relative shrink-0 sm:w-auto">
+      <button type="button"
+              @click="showRatingPopup = !showRatingPopup"
+              class="inline-flex h-[1.875rem] shrink-0 items-center gap-0.5 rounded-full border border-amber-400/18 bg-amber-500/[0.07] pl-0 pr-1.5 text-[12px] text-white shadow-sm transition-colors duration-200 hover:border-amber-300/28 hover:bg-amber-500/[0.11] sm:h-8 sm:gap-2 sm:pr-3 sm:text-sm">
+        <span class="sr-only">Your score</span>
+        <span class="-my-px -ml-px flex h-[1.875rem] w-[1.875rem] shrink-0 items-center justify-center rounded-full border border-amber-400/28 bg-amber-500/14 sm:h-8 sm:w-8">
+          {% include "app/icons/star.svg" with classes="h-3.5 w-3.5 text-yellow-400 fill-yellow-400 sm:h-4 sm:w-4" %}
+        </span>
+        <span class="inline-flex items-center gap-1 sm:gap-2">
+          <span class="text-[12px] font-semibold text-white sm:text-sm {% if ep_score is None %}hidden{% endif %}"
+                :class="rating ? '' : 'hidden'"
+                x-text="formatRating(rating)">{% if ep_score is not None %}{{ ep_score|score_display:user }}{% endif %}</span>
+          <span class="text-[12px] text-gray-500 sm:text-sm {% if ep_score is None %}hidden{% endif %}"
+                :class="rating ? '' : 'hidden'">|</span>
+          <span class="text-[12px] font-medium text-gray-200 sm:text-sm"
+                x-text="rating ? 'Edit rating' : 'Add rating'">{% if ep_score is not None %}Edit rating{% else %}Add rating{% endif %}</span>
+        </span>
+      </button>
+      <div x-show="showRatingPopup"
+           @click.outside="showRatingPopup = false; isHovering = false"
+           class="absolute left-0 top-full mt-2 w-[250px] rounded-lg border border-gray-700 bg-[#2a2f35] p-3 shadow-lg z-10"
+           @mouseenter="isHovering = true"
+           @mouseleave="isHovering = false; hoverRating = null">
+        <div class="flex justify-between mb-1">
+          {% with rating_range=user|rating_scale_max|get_range %}
+            {% for rating_value in rating_range %}
+              <button @click="if (rating === {{ rating_value }}) { rating = null; } else { rating = {{ rating_value }}; } showRatingPopup = false; isHovering = false"
+                      @mouseenter="hoverRating = {{ rating_value }}"
+                      hx-post="{% url 'update_episode_score' current_instance.id episode_number %}"
+                      hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                      hx-vals='{"score": {{ rating_value }}, "toggle": true}'
+                      hx-trigger="click"
+                      hx-swap="none"
+                      class="focus:outline-none flex flex-col items-center cursor-pointer">
+                <div :class="{ 'text-yellow-400': {{ rating_value }} <= (isHovering ? hoverRating : rating), 'text-gray-600': {{ rating_value }} > (isHovering ? hoverRating : rating) }">
+                  {% include "app/icons/star.svg" with classes="w-5 h-5 hover:scale-110 transition-transform" %}
+                </div>
+                <span class="text-xs mt-1 text-gray-400">{{ rating_value }}</span>
+              </button>
+            {% endfor %}
+          {% endwith %}
+        </div>
+      </div>
+    </div>
+    {% endwith %}
+  {% endif %}
+</div>

--- a/src/templates/app/episode_details.html
+++ b/src/templates/app/episode_details.html
@@ -71,10 +71,7 @@
     </div>
 
     <div class="flex flex-col sm:contents">
-      {# Score chips row — mirrors media_details.html order-2/order-1 chip row.
-         Render whenever a TMDB score exists OR the viewer is logged in with an
-         episode, so the always-present rating-chip slot is in the DOM on first
-         load (before any watch) and episode_save can OOB-swap it in place. #}
+      {# Score chips row — mirrors media_details.html order-2/order-1 chip row. Render whenever a TMDB score exists OR the viewer is logged in with an episode, so the always-present rating-chip slot is in the DOM on first load (before any watch) and episode_save can OOB-swap it in place. #}
       {% if episode_metadata.score_count or not public_view and episode %}
         <div class="order-2 mt-0 mb-5 flex w-full items-center justify-between gap-0.5 sm:order-1 sm:mt-4 sm:flex-wrap sm:justify-start sm:gap-2">
           {# TMDB provider score chip #}
@@ -93,8 +90,7 @@
               <span class="text-[12px] text-gray-300 sm:text-sm">{{ episode_metadata.score_count|intcomma }} vote{{ episode_metadata.score_count|pluralize }}</span>
             </div>
           {% endif %}
-          {# User episode rating chip — always-present slot so it can be OOB-swapped
-             into place on first watch without a page refresh. #}
+          {# User episode rating chip — always-present slot so it can be OOB-swapped into place on first watch without a page refresh. #}
           {% if not public_view and episode %}
             {% include "app/components/detail_episode_rating_chip.html" with episode=episode current_instance=current_instance episode_number=episode_number user=user csrf_token=csrf_token source=source media_id=media_id season_number=season_number public_view=public_view %}
           {% endif %}

--- a/src/templates/app/episode_details.html
+++ b/src/templates/app/episode_details.html
@@ -71,8 +71,11 @@
     </div>
 
     <div class="flex flex-col sm:contents">
-      {# Score chips row — mirrors media_details.html order-2/order-1 chip row #}
-      {% if episode_metadata.score_count or not public_view and episode and episode.history and current_instance %}
+      {# Score chips row — mirrors media_details.html order-2/order-1 chip row.
+         Render whenever a TMDB score exists OR the viewer is logged in with an
+         episode, so the always-present rating-chip slot is in the DOM on first
+         load (before any watch) and episode_save can OOB-swap it in place. #}
+      {% if episode_metadata.score_count or not public_view and episode %}
         <div class="order-2 mt-0 mb-5 flex w-full items-center justify-between gap-0.5 sm:order-1 sm:mt-4 sm:flex-wrap sm:justify-start sm:gap-2">
           {# TMDB provider score chip #}
           {% if episode_metadata.score_count %}
@@ -90,62 +93,10 @@
               <span class="text-[12px] text-gray-300 sm:text-sm">{{ episode_metadata.score_count|intcomma }} vote{{ episode_metadata.score_count|pluralize }}</span>
             </div>
           {% endif %}
-          {# User episode rating chip — only when user has watched this episode #}
-          {% if not public_view and episode and episode.history and current_instance %}
-            {% with ep_score=episode.history.0.score %}
-            <div x-data="{
-              showRatingPopup: false,
-              rating: {% if ep_score is not None %}{{ ep_score|score_display:user }}{% else %}null{% endif %},
-              ratingScaleMax: {{ user|rating_scale_max }},
-              hoverRating: null,
-              isHovering: false,
-              formatRating(v) { if (v === null || v === undefined || v === '') return ''; return this.ratingScaleMax === 5 ? String(v) + '/5' : String(v); }
-            }"
-                 class="relative shrink-0 sm:w-auto">
-              <button type="button"
-                      @click="showRatingPopup = !showRatingPopup"
-                      class="inline-flex h-[1.875rem] shrink-0 items-center gap-0.5 rounded-full border border-amber-400/18 bg-amber-500/[0.07] pl-0 pr-1.5 text-[12px] text-white shadow-sm transition-colors duration-200 hover:border-amber-300/28 hover:bg-amber-500/[0.11] sm:h-8 sm:gap-2 sm:pr-3 sm:text-sm">
-                <span class="sr-only">Your score</span>
-                <span class="-my-px -ml-px flex h-[1.875rem] w-[1.875rem] shrink-0 items-center justify-center rounded-full border border-amber-400/28 bg-amber-500/14 sm:h-8 sm:w-8">
-                  {% include "app/icons/star.svg" with classes="h-3.5 w-3.5 text-yellow-400 fill-yellow-400 sm:h-4 sm:w-4" %}
-                </span>
-                <span class="inline-flex items-center gap-1 sm:gap-2">
-                  <span class="text-[12px] font-semibold text-white sm:text-sm {% if ep_score is None %}hidden{% endif %}"
-                        :class="rating ? '' : 'hidden'"
-                        x-text="formatRating(rating)">{% if ep_score is not None %}{{ ep_score|score_display:user }}{% endif %}</span>
-                  <span class="text-[12px] text-gray-500 sm:text-sm {% if ep_score is None %}hidden{% endif %}"
-                        :class="rating ? '' : 'hidden'">|</span>
-                  <span class="text-[12px] font-medium text-gray-200 sm:text-sm"
-                        x-text="rating ? 'Edit rating' : 'Add rating'">{% if ep_score is not None %}Edit rating{% else %}Add rating{% endif %}</span>
-                </span>
-              </button>
-              <div x-show="showRatingPopup"
-                   @click.outside="showRatingPopup = false; isHovering = false"
-                   class="absolute left-0 top-full mt-2 w-[250px] rounded-lg border border-gray-700 bg-[#2a2f35] p-3 shadow-lg z-10"
-                   @mouseenter="isHovering = true"
-                   @mouseleave="isHovering = false; hoverRating = null">
-                <div class="flex justify-between mb-1">
-                  {% with rating_range=user|rating_scale_max|get_range %}
-                    {% for rating_value in rating_range %}
-                      <button @click="if (rating === {{ rating_value }}) { rating = null; } else { rating = {{ rating_value }}; } showRatingPopup = false; isHovering = false"
-                              @mouseenter="hoverRating = {{ rating_value }}"
-                              hx-post="{% url 'update_episode_score' current_instance.id episode_number %}"
-                              hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-                              hx-vals='{"score": {{ rating_value }}, "toggle": true}'
-                              hx-trigger="click"
-                              hx-swap="none"
-                              class="focus:outline-none flex flex-col items-center cursor-pointer">
-                        <div :class="{ 'text-yellow-400': {{ rating_value }} <= (isHovering ? hoverRating : rating), 'text-gray-600': {{ rating_value }} > (isHovering ? hoverRating : rating) }">
-                          {% include "app/icons/star.svg" with classes="w-5 h-5 hover:scale-110 transition-transform" %}
-                        </div>
-                        <span class="text-xs mt-1 text-gray-400">{{ rating_value }}</span>
-                      </button>
-                    {% endfor %}
-                  {% endwith %}
-                </div>
-              </div>
-            </div>
-            {% endwith %}
+          {# User episode rating chip — always-present slot so it can be OOB-swapped
+             into place on first watch without a page refresh. #}
+          {% if not public_view and episode %}
+            {% include "app/components/detail_episode_rating_chip.html" with episode=episode current_instance=current_instance episode_number=episode_number user=user csrf_token=csrf_token source=source media_id=media_id season_number=season_number public_view=public_view %}
           {% endif %}
         </div>
       {% endif %}
@@ -154,19 +105,9 @@
       {% if not public_view and episode and episode.actions_enabled %}
         <div class="order-1 mb-6 flex flex-col gap-3 sm:order-2 sm:flex-row sm:flex-wrap sm:items-center">
           <div class="mt-4 mb-5 flex flex-wrap gap-2">
-            {# Hero track button — same size/shape as detail_track_action large button #}
+            {# Hero track button — OOB-addressable so episode_save can flip it in place #}
             <div x-data="{ trackOpen: false }" class="w-full sm:w-auto sm:shrink-0">
-              <button type="button"
-                      @click="trackOpen = true"
-                      class="inline-flex w-full items-center justify-center gap-3 rounded-xl px-5 py-3 text-white shadow-sm transition duration-300 cursor-pointer sm:w-auto {% if episode.history %}bg-indigo-600 hover:bg-indigo-700{% else %}bg-gray-600 hover:bg-gray-700{% endif %}">
-                {% if episode.history %}
-                  {% include "app/icons/eye.svg" with classes="w-5 h-5 shrink-0" %}
-                  <span class="font-medium">Watched</span>
-                {% else %}
-                  {% include "app/icons/eye-closed.svg" with classes="w-5 h-5 shrink-0" %}
-                  <span class="font-medium">Mark Watched</span>
-                {% endif %}
-              </button>
+              {% include "app/components/detail_episode_hero_track_button.html" with episode=episode source=source media_id=media_id season_number=season_number episode_number=episode_number %}
               {% include "app/components/fill_track_episode.html" with request=request media=episode episode=episode episode_title=episode_title csrf_token=csrf_token TRACK_TIME=TRACK_TIME user=user only %}
             </div>
 


### PR DESCRIPTION
## Summary

Fixes for the standalone episode details page (`/details/.../season/N/episode/M`). Two commits:

### 1. Mark Watched / drop now update in place (`f20aca90`)

Clicking **Mark Watched** on the episode page showed the success toast but didn't flip the button to "Watched" or reveal the rating chip until a manual refresh. `episode_save` emitted out-of-band fragments whose ids only exist on the *season* details page (`episode-track-button-{item.id}`, `episode-history-{item.id}`, `season-progress-*`), so HTMX silently dropped the swaps on the episode page. The rating chip was additionally gated on `episode.history`, so it was absent from the DOM on the first watch.

Render page-appropriate OOB variants by detecting the standalone episode page from the `next` path:
- Add `detail_episode_hero_track_button.html` — the hero pill button in an OOB-addressable container keyed on the stable source/media/season/episode identifiers instead of `episode.item.id` (which doesn't exist before the first watch).
- Add `detail_episode_rating_chip.html` — an always-present rating-chip slot, empty until history exists, so it can be swapped in on the first watch.
- `episode_details.html` includes both partials; the chip row renders for logged-in viewers regardless of existing history so the slot is in the DOM on initial load.
- Extract `_write_episode_save_oob()`, used from both `episode_save` and `episode_drop`: emits the hero button + rating chip OOB for the episode page (skipping season-only progress spans) and the original season-page fragments otherwise, leaving season-list behaviour unchanged.

### 2. Rating chip score + leaked comments (`57acf398`)

- **Score didn't show until reload.** After rating an episode the button text flipped to "Edit rating" but the score number and `|` separator stayed hidden until refresh. `hidden` was present in both the static `class` and the Alpine `:class="rating ? '' : 'hidden'"` binding; Alpine merges static classes with `:class`, so the static `hidden` was never removed. Replaced the static-hidden + `:class` combo with `x-show="rating"` (plus `x-cloak` to avoid a pre-init flash) so visibility tracks the rating reactively.
- **Leaked template comments.** Several `{# … #}` comments spanned multiple lines. Django only strips single-line `{# … #}`, so multi-line ones rendered as literal text on the page. Collapsed them in `episode_details.html`, `detail_episode_rating_chip.html`, and `detail_episode_hero_track_button.html`.

## Validation

Verified locally against the running dev server: Mark Watched flips the button and reveals the chip in place (including first watch), the score appears immediately after rating, and the leaked comment text is gone. Commit 2 is template-only; commit 1 touches `save_views.py` OOB rendering (no model/migration changes).

## Risk

Low — episode-page rendering and presentation only; season-page behaviour is unchanged.
