### PR TITLE
Add support for albums/artists on home screen

### DIFF
--- a/src/templates/app/components/media_card.html
+++ b/src/templates/app/components/media_card.html
@@ -24,7 +24,7 @@
                    loading="lazy">
             </div>
           {% else %}
-            <a href="{% if media.album %}{{ media.album|music_album_url }}{% elif use_podcast_show|default:False and podcast_show %}{% url 'media_details' source='pocketcasts' media_type='podcast' media_id=podcast_show.podcast_uuid title=podcast_show.slug|default:podcast_show.title|default:podcast_show.podcast_uuid|slug %}{% elif public_view|default:False %}{{ item|media_url }}?public_view=1{% else %}{{ item|media_url }}{% endif %}">
+            <a href="{% if media.album %}{{ media.album|music_album_url }}{% elif media.artist %}{{ media.artist|music_artist_url }}{% elif use_podcast_show|default:False and podcast_show %}{% url 'media_details' source='pocketcasts' media_type='podcast' media_id=podcast_show.podcast_uuid title=podcast_show.slug|default:podcast_show.title|default:podcast_show.podcast_uuid|slug %}{% elif public_view|default:False %}{{ item|media_url }}?public_view=1{% else %}{{ item|media_url }}{% endif %}">
               <img alt="{% if use_podcast_show|default:False and podcast_show %}{{ podcast_show.title }}{% elif resolved_media_type == MediaTypes.SEASON.value %}{{ season_card_title_override|default:resolved_season_card_title }}{% else %}{{ resolved_item_title|default:title }}{% endif %}"
                    class="media-card-poster {% if hover_action_mode != 'discover' %}lazyload{% endif %} w-full {% if from_grid %}{% if resolved_media_type == 'podcast' or resolved_media_type == 'music' %}aspect-[1/1]{% else %}aspect-[2/3] aspect-2/3{% endif %}{% else %}h-48{% endif %} bg-[#3e454d] {% if image_override|default:item.image|default:IMG_NONE != IMG_NONE %}object-cover{% endif %}"
                    data-image-source="{{ image_source|default:'primary' }}"
@@ -225,7 +225,7 @@
               {# Darkening background layer #}
               <div class="absolute inset-0 bg-black/50 z-0"></div>
               
-              <a href="{% if use_podcast_show|default:False and podcast_show %}{% url 'media_details' source='pocketcasts' media_type='podcast' media_id=podcast_show.podcast_uuid title=podcast_show.slug|default:podcast_show.title|default:podcast_show.podcast_uuid|slug %}{% else %}{{ item|media_url }}{% endif %}" class="absolute inset-0 z-0"></a>
+              <a href="{% if media.album %}{{ media.album|music_album_url }}{% elif media.artist %}{{ media.artist|music_artist_url }}{% elif use_podcast_show|default:False and podcast_show %}{% url 'media_details' source='pocketcasts' media_type='podcast' media_id=podcast_show.podcast_uuid title=podcast_show.slug|default:podcast_show.title|default:podcast_show.podcast_uuid|slug %}{% else %}{{ item|media_url }}{% endif %}" class="absolute inset-0 z-0"></a>
 
               <div class="relative z-10 flex items-center justify-center space-x-2.5"
                    {% if list_ordering_enabled|default:False %}
@@ -379,7 +379,7 @@
                 <h3 class="media-card-title font-medium text-white line-clamp-1 text-sm leading-tight min-w-0"
                     title="{% if resolved_media_type == MediaTypes.SEASON.value %}{{ season_card_title_override|default:resolved_season_card_title }}{% else %}{{ resolved_item_title|default:title }}{% endif %}">{% if resolved_media_type == MediaTypes.SEASON.value %}{{ season_card_title_override|default:resolved_season_card_title }}{% else %}{{ resolved_item_title|default:title }}{% endif %}</h3>
               {% else %}
-                <a href="{% if use_podcast_show|default:False and podcast_show %}{% url 'media_details' source='pocketcasts' media_type='podcast' media_id=podcast_show.podcast_uuid title=podcast_show.slug|default:podcast_show.title|default:podcast_show.podcast_uuid|slug %}{% elif public_view|default:False %}{{ item|media_url }}?public_view=1{% else %}{{ item|media_url }}{% endif %}"
+                <a href="{% if media.album %}{{ media.album|music_album_url }}{% elif media.artist %}{{ media.artist|music_artist_url }}{% elif use_podcast_show|default:False and podcast_show %}{% url 'media_details' source='pocketcasts' media_type='podcast' media_id=podcast_show.podcast_uuid title=podcast_show.slug|default:podcast_show.title|default:podcast_show.podcast_uuid|slug %}{% elif public_view|default:False %}{{ item|media_url }}?public_view=1{% else %}{{ item|media_url }}{% endif %}"
                    class="media-card-title text-sm font-semibold text-white {% if not public_view|default:False %}hover:text-indigo-400{% endif %} transition duration-300 line-clamp-1 min-w-0"
                    title="{% if resolved_media_type == MediaTypes.SEASON.value %}{{ season_card_title_override|default:resolved_season_card_title }}{% else %}{{ resolved_item_title|default:title }}{% endif %}">{% if resolved_media_type == MediaTypes.SEASON.value %}{{ season_card_title_override|default:resolved_season_card_title }}{% else %}{{ resolved_item_title|default:title }}{% endif %}</a>
               {% endif %}
@@ -477,7 +477,13 @@
               </p>
             {% endif %}
             {% if from_grid %}
-              {% if show_episode_identity|default:False and item.season_number != None and item.episode_number != None %}
+              {% if media|safe_attr:"home_music_card" %}
+                {% if media.card_subtitle_text %}
+                  <p class="media-card-year text-xs text-gray-400 mt-1 line-clamp-1">{{ media.card_subtitle_text }}</p>
+                {% elif media.card_subtitle_date %}
+                  <p class="media-card-year text-xs text-gray-400 mt-1 line-clamp-1">{{ media.card_subtitle_date|user_date_format:user }}</p>
+                {% endif %}
+              {% elif show_episode_identity|default:False and item.season_number != None and item.episode_number != None %}
                 <p class="media-card-year text-xs text-gray-400 mt-1">S{{ item.season_number|stringformat:"02d" }} E{{ item.episode_number|stringformat:"02d" }}</p>
               {% elif use_podcast_show|default:False and podcast_show %}
                 <p class="media-card-year text-xs text-gray-400 mt-1 line-clamp-1">{{ podcast_show.title }}</p>

--- a/src/templates/users/home_screen.html
+++ b/src/templates/users/home_screen.html
@@ -482,6 +482,15 @@
           else if (status === 'Dropped') parts.push('Dropped');
           else parts.push('Library');
 
+          if (section.media_type === 'music') {
+            const subview = row.filters?.subview || 'tracks';
+            const subviewField = (section.filter_fields || []).find(field => field.key === 'subview');
+            const subviewOption = (subviewField?.options || []).find(option => option.value === subview);
+            const subviewLabel = subviewOption ? subviewOption.label : subview;
+            if (parts[0] === 'Library') parts[0] = subviewLabel;
+            else parts.splice(1, 0, subviewLabel);
+          }
+
           const labelFor = (key, value) => {
             const field = (section.filter_fields || []).find(candidate => candidate.key === key);
             if (!field) return value;
@@ -557,6 +566,7 @@
           const defaults = this.defaultFilters(section, 'library_query');
           for (const [key, value] of Object.entries(defaults)) {
             if (key === 'status') continue;
+            if (key === 'subview') continue;
             row.filters[key] = value;
           }
         },
@@ -593,7 +603,7 @@
         },
         defaultFilters(section, rowType) {
           if (rowType !== 'library_query') return {};
-          return {
+          const defaults = {
             status: 'In progress',
             progress: ['tv', 'anime'].includes(section.media_type) ? 'not_caught_up' : 'all',
             rating: 'all',
@@ -611,6 +621,8 @@
             tag: '',
             tag_exclude: ''
           };
+          if (section.media_type === 'music') defaults.subview = 'tracks';
+          return defaults;
         },
         removeRow(section, clientId) {
           section.rows = section.rows.filter(row => row.client_id !== clientId);

--- a/src/users/home_screen.py
+++ b/src/users/home_screen.py
@@ -37,6 +37,7 @@ from users.models import (
     HomeSortChoices,
     ListDetailSortChoices,
     MediaSortChoices,
+    MediaStatusChoices,
 )
 
 RECENTLY_UNRATED_DAYS = 7
@@ -1467,21 +1468,7 @@ def _build_recent_music_album_entries(media_items: list[object]) -> list[HomeRow
             self.next_event = None
             self.score = None
             self.title = album.title
-            album_media_id = f"album_{album.id}"
-            self.item, _ = Item.objects.get_or_create(
-                media_id=album_media_id,
-                source=Sources.MANUAL.value,
-                media_type=MediaTypes.MUSIC.value,
-                defaults={
-                    "title": album.title,
-                    "image": album.image or settings.IMG_NONE,
-                },
-            )
-            desired_image = album.image or settings.IMG_NONE
-            if self.item.title != album.title or self.item.image != desired_image:
-                self.item.title = album.title
-                self.item.image = desired_image
-                self.item.save(update_fields=["title", "image"])
+            self.item = _music_shell_item(f"album_{album.id}", album.title, album.image)
             self.primary_track = primary_track
 
     entries = [
@@ -2054,11 +2041,16 @@ def home_row_destination_url(row: HomeScreenRow, user) -> str:
 
     if row.row_type == HomeScreenRowTypeChoices.RECENTLY_UNRATED:
         params["rating"] = "not_rated"
+        params["status"] = MediaStatusChoices.ALL.value
     else:
-        for key, raw_value in _normalized_filter_payload(
-            row.filters or {},
-            row.media_type,
-        ).items():
+        normalized = _normalized_filter_payload(row.filters or {}, row.media_type)
+        status_value = normalized.get("status") or "all"
+        params["status"] = (
+            MediaStatusChoices.ALL.value if status_value == "all" else status_value
+        )
+        for key, raw_value in normalized.items():
+            if key == "status":
+                continue
             value = raw_value
             if isinstance(value, (list, tuple)):
                 value = value[0] if len(value) == 1 else None

--- a/src/users/home_screen.py
+++ b/src/users/home_screen.py
@@ -49,6 +49,30 @@ SQUARE_HOME_MEDIA_TYPES = {
 WIDE_SQUARE_HOME_MEDIA_TYPES = {
     MediaTypes.MUSIC.value,
 }
+# Music has a single Home section/header, but each row under it can independently
+# target tracks, albums, or artists (mirrors the media-list subview toggle).
+# A row's choice is stored in filters["subview"]; rows of different types mix freely.
+MUSIC_SUBVIEW_TRACKS = "tracks"
+MUSIC_SUBVIEW_ALBUMS = "albums"
+MUSIC_SUBVIEW_ARTISTS = "artists"
+MUSIC_SUBVIEW_DEFAULT = MUSIC_SUBVIEW_TRACKS
+# Ordered for the settings filter menu (media type sits at the top of the list).
+MUSIC_SUBVIEW_VALUES = (
+    MUSIC_SUBVIEW_ARTISTS,
+    MUSIC_SUBVIEW_ALBUMS,
+    MUSIC_SUBVIEW_TRACKS,
+)
+MUSIC_SUBVIEW_LABELS = {
+    MUSIC_SUBVIEW_ARTISTS: "Artists",
+    MUSIC_SUBVIEW_ALBUMS: "Albums",
+    MUSIC_SUBVIEW_TRACKS: "Tracks",
+}
+
+
+def _canonical_music_subview(value, default: str = MUSIC_SUBVIEW_DEFAULT) -> str:
+    """Normalize a music subview value to a known choice."""
+    raw_value = str(value or "").strip().lower()
+    return raw_value if raw_value in MUSIC_SUBVIEW_VALUES else default
 AUTHOR_MEDIA_TYPES = {
     MediaTypes.BOOK.value,
     MediaTypes.MANGA.value,
@@ -94,7 +118,7 @@ HOME_ONLY_SORTS = {
 HOME_SCREEN_FILTER_KEYS = tuple(
     dict.fromkeys(
         key
-        for key in (*smart_rules.SMART_FILTER_KEYS, "progress")
+        for key in (*smart_rules.SMART_FILTER_KEYS, "progress", "subview")
         if key != "search"
     ),
 )
@@ -248,6 +272,7 @@ SUPPORTED_FILTERS_BY_MEDIA_TYPE = {
         "tag_exclude",
     },
     MediaTypes.MUSIC.value: {
+        "subview",
         "status",
         "rating",
         "collection",
@@ -677,6 +702,14 @@ def build_filter_field_data(
 
     field_definitions = [
         {
+            "key": "subview",
+            "label": "Media Type",
+            "options": [
+                {"value": value, "label": MUSIC_SUBVIEW_LABELS[value]}
+                for value in MUSIC_SUBVIEW_VALUES
+            ],
+        },
+        {
             "key": "status",
             "label": "Status",
             "options": [
@@ -884,6 +917,15 @@ def describe_library_query(filters: dict, user, media_type: str) -> str:
     else:
         parts = ["Library"]
 
+    if media_type == MediaTypes.MUSIC.value:
+        subview_label = MUSIC_SUBVIEW_LABELS[
+            _canonical_music_subview(normalized.get("subview"))
+        ]
+        if parts[0] == "Library":
+            parts[0] = subview_label
+        else:
+            parts.insert(1, subview_label)
+
     for key in (
         "progress",
         "rating",
@@ -1048,6 +1090,8 @@ def toggle_home_row_direction(user, row_id: int) -> HomeScreenRow:
 
 def _normalized_filter_payload(filters: dict | None, media_type: str) -> dict:
     raw_filters = dict(filters or {})
+    # subview is a music-only dimension, not a smart-rule filter. handling separately
+    raw_subview = raw_filters.pop("subview", None)
     if "status" in raw_filters:
         raw_filters["status"] = _canonical_status_filter(
             raw_filters.get("status"),
@@ -1071,10 +1115,14 @@ def _normalized_filter_payload(filters: dict | None, media_type: str) -> dict:
         raw_filters.get("progress", normalized.get("progress")),
         HOME_QUERY_DEFAULT_FILTERS["progress"],
     )
-    return {
+    payload = {
         key: normalized.get(key, HOME_QUERY_DEFAULT_FILTERS.get(key, ""))
         for key in HOME_SCREEN_FILTER_KEYS
+        if key != "subview"
     }
+    if media_type == MediaTypes.MUSIC.value:
+        payload["subview"] = _canonical_music_subview(raw_subview)
+    return payload
 
 
 def _row_payload_to_model(user, media_type: str, row_payload: dict, position: int) -> HomeScreenRow:
@@ -1183,6 +1231,9 @@ def validate_library_row_filters(raw_filters: dict | None, media_type: str) -> d
     raw_source = str(raw_filters.get("source", normalized["source"]) or "").strip().lower()
     if raw_source and raw_source not in Sources.values:
         raise HomeScreenValidationError(f"Unsupported source filter for {media_type}.")
+    raw_subview = str(raw_filters.get("subview", "") or "").strip().lower()
+    if raw_subview and raw_subview not in MUSIC_SUBVIEW_VALUES:
+        raise HomeScreenValidationError(f"Unsupported media type for {media_type}.")
     return normalized
 
 
@@ -1258,6 +1309,131 @@ def _annotate_home_card_images(media_items):
     ]
     if season_items:
         BasicMedia.objects._fix_missing_season_images(season_items)
+
+
+def _music_shell_item(media_id: str, title: str, image: str | None) -> Item:
+    """Get or refresh the lightweight Item used to render a music Home card.
+
+    Album/artist tracking isn't backed by a media_type='music' Item, so we keep a
+    stable manual-source shell Item per album/artist purely for card display.
+    """
+    item, _ = Item.objects.get_or_create(
+        media_id=media_id,
+        source=Sources.MANUAL.value,
+        media_type=MediaTypes.MUSIC.value,
+        defaults={"title": title, "image": image or settings.IMG_NONE},
+    )
+    desired_image = image or settings.IMG_NONE
+    if item.title != title or item.image != desired_image:
+        item.title = title
+        item.image = desired_image
+        item.save(update_fields=["title", "image"])
+    return item
+
+
+class _MusicTrackerAdapter:
+    """Media-like wrapper around an Album/Artist tracker for Home card rendering."""
+
+    def __init__(self, item: Item, tracker: object):
+        self.item = item
+        self.id = tracker.id
+        self.status = tracker.status
+        self.aggregated_status = tracker.status
+        self.score = getattr(tracker, "score", None)
+        self.next_event = None
+        self.start_date = getattr(tracker, "start_date", None)
+        self.end_date = getattr(tracker, "end_date", None)
+        self.created_at = getattr(tracker, "created_at", None)
+        self.last_played_at = (
+            getattr(tracker, "end_date", None) or getattr(tracker, "created_at", None)
+        )
+        self.title = item.title
+
+
+class _AlbumHomeAdapter(_MusicTrackerAdapter):
+    def __init__(self, item: Item, tracker: object, album: object):
+        super().__init__(item, tracker)
+        self.album = album
+        self.home_music_card = True
+        artist = getattr(album, "artist", None)
+        self.card_subtitle_text = getattr(artist, "name", "") or ""
+        self.card_subtitle_date = getattr(tracker, "created_at", None)
+
+
+class _ArtistHomeAdapter(_MusicTrackerAdapter):
+    def __init__(self, item: Item, tracker: object, artist: object):
+        super().__init__(item, tracker)
+        self.artist = artist
+        self.home_music_card = True
+        self.card_subtitle_text = ""
+        self.card_subtitle_date = getattr(tracker, "created_at", None)
+
+
+def _apply_music_tracker_rating_filter(trackers, rating_filter: str):
+    if rating_filter == "rated":
+        return trackers.filter(score__isnull=False)
+    if rating_filter == "not_rated":
+        return trackers.filter(score__isnull=True)
+    return trackers
+
+
+def _build_album_home_entries(user, filters: dict, sort_by: str, direction: str) -> list[HomeRowEntry]:
+    """Build Home entries from the user's tracked albums (AlbumTracker)."""
+    from app.models import AlbumTracker  # noqa: PLC0415
+
+    status_filter = filters.get("status", "all")
+    trackers = AlbumTracker.objects.filter(user=user).select_related(
+        "album", "album__artist",
+    )
+    if status_filter and status_filter != "all":
+        trackers = trackers.filter(status=status_filter)
+    trackers = _apply_music_tracker_rating_filter(trackers, filters.get("rating", "all"))
+
+    entries = []
+    for tracker in trackers:
+        album = tracker.album
+        if not album:
+            continue
+        item = _music_shell_item(f"album_{album.id}", album.title, album.image)
+        entries.append(
+            HomeRowEntry(
+                item=item,
+                media=_AlbumHomeAdapter(item, tracker, album),
+                show_progress_controls=False,
+            ),
+        )
+    return sort_home_entries(entries, sort_by, direction)
+
+
+def _build_artist_home_entries(user, filters: dict, sort_by: str, direction: str) -> list[HomeRowEntry]:
+    """Build Home entries from the user's tracked artists (ArtistTracker)."""
+    from app.models import ArtistTracker  # noqa: PLC0415
+
+    status_filter = filters.get("status", "all")
+    trackers = (
+        ArtistTracker.objects.filter(user=user)
+        .exclude(artist__name__isnull=True)
+        .exclude(artist__name__exact="")
+        .select_related("artist")
+    )
+    if status_filter and status_filter != "all":
+        trackers = trackers.filter(status=status_filter)
+    trackers = _apply_music_tracker_rating_filter(trackers, filters.get("rating", "all"))
+
+    entries = []
+    for tracker in trackers:
+        artist = tracker.artist
+        if not artist:
+            continue
+        item = _music_shell_item(f"artist_{artist.id}", artist.name, getattr(artist, "image", None))
+        entries.append(
+            HomeRowEntry(
+                item=item,
+                media=_ArtistHomeAdapter(item, tracker, artist),
+                show_progress_controls=False,
+            ),
+        )
+    return sort_home_entries(entries, sort_by, direction)
 
 
 def _build_recent_music_album_entries(media_items: list[object]) -> list[HomeRowEntry]:
@@ -1702,6 +1878,17 @@ def sort_home_entries(entries: list[HomeRowEntry], sort_by: str, direction: str)
 
 def _library_query_entries(user, row: HomeScreenRow) -> list[HomeRowEntry]:
     normalized_filters = _normalized_filter_payload(row.filters or {}, row.media_type)
+    if row.media_type == MediaTypes.MUSIC.value:
+        subview = _canonical_music_subview(normalized_filters.get("subview"))
+        if subview == MUSIC_SUBVIEW_ALBUMS:
+            return _build_album_home_entries(
+                user, normalized_filters, row.sort_by, row.direction,
+            )
+        if subview == MUSIC_SUBVIEW_ARTISTS:
+            return _build_artist_home_entries(
+                user, normalized_filters, row.sort_by, row.direction,
+            )
+        # MUSIC_SUBVIEW_TRACKS falls through to the standard Music/Item query below.
     status_filter = normalized_filters.get("status", "all")
     rule_payload = {
         "media_types": [row.media_type],

--- a/src/users/tests/views/test_home_music_subview.py
+++ b/src/users/tests/views/test_home_music_subview.py
@@ -6,7 +6,11 @@ from django.test import TestCase
 from app.models import MediaTypes, Status
 from app.models.music import Album, AlbumTracker, Artist, ArtistTracker
 from users import home_screen
-from users.models import HomeScreenRow, HomeScreenRowTypeChoices
+from users.models import (
+    HomeScreenRow,
+    HomeScreenRowTypeChoices,
+    MediaStatusChoices,
+)
 
 
 class MusicSubviewHomeTests(TestCase):
@@ -119,6 +123,25 @@ class MusicSubviewHomeTests(TestCase):
         self.client.force_login(self.user)
         response = self.client.get("/settings/home-screen")
         self.assertEqual(response.status_code, 200)
+
+    def test_destination_url_pins_status_all_for_all_status_row(self):
+        row = self._add_music_row("tracks", MediaStatusChoices.ALL.value)
+        url = home_screen.home_row_destination_url(row, self.user)
+        self.assertIn(f"status={MediaStatusChoices.ALL.value}", url)
+        self.assertIn("subview=tracks", url)
+
+    def test_destination_url_passes_status_and_subview_for_albums(self):
+        row = self._add_music_row("albums", Status.PLANNING.value)
+        url = home_screen.home_row_destination_url(row, self.user)
+        self.assertIn("status=Planning", url)
+        self.assertIn("subview=albums", url)
+
+    def test_albums_upcoming_sort_does_not_crash(self):
+        row = self._add_music_row("albums", Status.PLANNING.value)
+        row.sort_by = "upcoming"
+        row.direction = "asc"
+        entries = home_screen._library_query_entries(self.user, row)
+        self.assertTrue(any(e.item.title == "A Night at the Opera" for e in entries))
 
     def test_row_title_includes_subview_label(self):
         title = home_screen.describe_library_query(

--- a/src/users/tests/views/test_home_music_subview.py
+++ b/src/users/tests/views/test_home_music_subview.py
@@ -1,0 +1,129 @@
+"""Smoke tests for music subview Home rows (albums/artists/tracks)."""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from app.models import MediaTypes, Status
+from app.models.music import Album, AlbumTracker, Artist, ArtistTracker
+from users import home_screen
+from users.models import HomeScreenRow, HomeScreenRowTypeChoices
+
+
+class MusicSubviewHomeTests(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(
+            username="musicfan", password="pw",
+        )
+        self.user.music_enabled = True
+        self.user.save(update_fields=["music_enabled"])
+
+        self.artist = Artist.objects.create(name="Queen", image="http://x/a.jpg")
+        self.album = Album.objects.create(
+            title="A Night at the Opera", artist=self.artist, image="http://x/al.jpg",
+        )
+        AlbumTracker.objects.create(
+            user=self.user, album=self.album, status=Status.PLANNING.value,
+        )
+        ArtistTracker.objects.create(
+            user=self.user, artist=self.artist, status=Status.IN_PROGRESS.value,
+        )
+
+    def _add_music_row(self, subview, status):
+        return HomeScreenRow.objects.create(
+            user=self.user,
+            media_type=MediaTypes.MUSIC.value,
+            position=10,
+            enabled=True,
+            row_type=HomeScreenRowTypeChoices.LIBRARY_QUERY,
+            sort_by="title",
+            direction="asc",
+            filters={"status": status, "subview": subview},
+        )
+
+    def _music_group(self, groups):
+        return next(
+            (g for g in groups if g["media_type"] == MediaTypes.MUSIC.value), None,
+        )
+
+    def test_albums_subview_surfaces_album_tracker(self):
+        self._add_music_row("albums", Status.PLANNING.value)
+        groups = home_screen.build_home_page_groups(self.user, items_limit=10)
+        group = self._music_group(groups)
+        self.assertIsNotNone(group, "music group should be present")
+        titles = [
+            entry.item.title
+            for row in group["rows"]
+            for entry in row["items"]
+        ]
+        self.assertIn("A Night at the Opera", titles)
+
+    def test_artists_subview_surfaces_artist_tracker(self):
+        self._add_music_row("artists", Status.IN_PROGRESS.value)
+        groups = home_screen.build_home_page_groups(self.user, items_limit=10)
+        group = self._music_group(groups)
+        self.assertIsNotNone(group)
+        titles = [
+            entry.item.title
+            for row in group["rows"]
+            for entry in row["items"]
+        ]
+        self.assertIn("Queen", titles)
+
+    def test_albums_status_filter_excludes_other_statuses(self):
+        self._add_music_row("albums", Status.IN_PROGRESS.value)
+        groups = home_screen.build_home_page_groups(self.user, items_limit=10)
+        # No in-progress albums tracked, so the music group should be empty/absent.
+        group = self._music_group(groups)
+        self.assertIsNone(group)
+
+    def test_validate_accepts_music_subview(self):
+        normalized = home_screen.validate_library_row_filters(
+            {"status": Status.PLANNING.value, "subview": "albums"},
+            MediaTypes.MUSIC.value,
+        )
+        self.assertEqual(normalized["subview"], "albums")
+
+    def test_validate_rejects_bad_subview(self):
+        with self.assertRaises(home_screen.HomeScreenValidationError):
+            home_screen.validate_library_row_filters(
+                {"subview": "nonsense"}, MediaTypes.MUSIC.value,
+            )
+
+    def test_subview_field_present_and_first_for_music(self):
+        fields = home_screen.build_filter_field_data(self.user, MediaTypes.MUSIC.value)
+        keys = [f["key"] for f in fields]
+        self.assertEqual(keys[0], "subview")
+
+    def test_subview_field_absent_for_non_music(self):
+        fields = home_screen.build_filter_field_data(self.user, MediaTypes.MOVIE.value)
+        self.assertNotIn("subview", [f["key"] for f in fields])
+
+    def test_home_page_renders_album_card(self):
+        self._add_music_row("albums", Status.PLANNING.value)
+        self.client.force_login(self.user)
+        response = self.client.get("/")
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "A Night at the Opera")
+        # Album cards carry the artist as the hover subtitle (mirrors the library).
+        self.assertContains(response, "Queen")
+
+    def test_home_page_renders_artist_card(self):
+        self._add_music_row("artists", Status.IN_PROGRESS.value)
+        self.client.force_login(self.user)
+        response = self.client.get("/")
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Queen")
+
+    def test_settings_page_renders(self):
+        self._add_music_row("albums", Status.PLANNING.value)
+        self.client.force_login(self.user)
+        response = self.client.get("/settings/home-screen")
+        self.assertEqual(response.status_code, 200)
+
+    def test_row_title_includes_subview_label(self):
+        title = home_screen.describe_library_query(
+            {"status": Status.PLANNING.value, "subview": "albums"},
+            self.user,
+            MediaTypes.MUSIC.value,
+        )
+        self.assertIn("Albums", title)


### PR DESCRIPTION
Previously, only individual tracks were supported on home screen. This adds support for the other existing media types, albums and artists.

### BEFORE

<img width="1277" height="848" alt="Screenshot 2026-06-24 at 12 05 39 PM" src="https://github.com/user-attachments/assets/7cee7816-c96a-4365-8619-12349300d371" />

### AFTER
<img width="1236" height="850" alt="Screenshot 2026-06-24 at 1 13 12 PM" src="https://github.com/user-attachments/assets/616e658a-d21a-4a55-94aa-2b79f6f1fa87" />

<img width="1236" height="785" alt="Screenshot 2026-06-24 at 1 13 25 PM" src="https://github.com/user-attachments/assets/4d1a063e-e9be-495d-baf2-d67797b8dc98" />

## Notes
**Code written with the help of Claude Opus.**