### PR TITLE
Fix media card display overlay issues

### DIFF
--- a/src/app/providers/openlibrary.py
+++ b/src/app/providers/openlibrary.py
@@ -247,7 +247,12 @@ def get_publish_date(response):
 
         date_formats = [
             "%B %d, %Y",  # January 19, 2001
+            "%b %d, %Y",  # Sep 27, 2016
             "%d %B %Y",  # 18 March 2025
+            "%d %b %Y",  # 27 Sep 2016
+            "%B %Y",  # March 2025
+            "%b %Y",  # Mar 2025
+            "%Y",  # 2016
         ]
         for date_format in date_formats:
             try:

--- a/src/app/tests/providers/test_metadata.py
+++ b/src/app/tests/providers/test_metadata.py
@@ -2378,3 +2378,48 @@ class CastOrderRegressionTests(TestCase):
         result = _normalize_credit_rows(rows)
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["sort_order"], 0)
+
+
+class OpenLibraryPublishDateTests(TestCase):
+    """Cover the free-form publish_date formats OpenLibrary returns."""
+
+    def test_abbreviated_month_comma(self):
+        result = openlibrary.get_publish_date({"publish_date": "Sep 27, 2016"})
+        self.assertEqual(result, "2016-09-27")
+
+    def test_full_month_comma(self):
+        result = openlibrary.get_publish_date({"publish_date": "January 19, 2001"})
+        self.assertEqual(result, "2001-01-19")
+
+    def test_day_full_month(self):
+        result = openlibrary.get_publish_date({"publish_date": "18 March 2025"})
+        self.assertEqual(result, "2025-03-18")
+
+    def test_day_abbreviated_month(self):
+        result = openlibrary.get_publish_date({"publish_date": "27 Sep 2016"})
+        self.assertEqual(result, "2016-09-27")
+
+    def test_month_and_year_only(self):
+        self.assertEqual(
+            openlibrary.get_publish_date({"publish_date": "March 2025"}),
+            "2025-03-01",
+        )
+        self.assertEqual(
+            openlibrary.get_publish_date({"publish_date": "Mar 2025"}),
+            "2025-03-01",
+        )
+
+    def test_year_only(self):
+        result = openlibrary.get_publish_date({"publish_date": "2016"})
+        self.assertEqual(result, "2016-01-01")
+
+    def test_copyright_prefix_stripped(self):
+        result = openlibrary.get_publish_date({"publish_date": "cop. Sep 27, 2016"})
+        self.assertEqual(result, "2016-09-27")
+
+    def test_unparseable_returns_original(self):
+        result = openlibrary.get_publish_date({"publish_date": "sometime in spring"})
+        self.assertEqual(result, "sometime in spring")
+
+    def test_missing_publish_date_returns_none(self):
+        self.assertIsNone(openlibrary.get_publish_date({}))

--- a/src/templates/app/components/_release_year_fetch_js.html
+++ b/src/templates/app/components/_release_year_fetch_js.html
@@ -35,7 +35,13 @@
           });
         } else {
           document.querySelectorAll(`.release-year-placeholder[data-item-id="${itemId}"]`).forEach(el => {
-            el.remove();
+            const progressText = el.dataset.progressText;
+            if (progressText) {
+              el.textContent = progressText;
+              el.classList.remove('release-year-placeholder');
+            } else {
+              el.remove();
+            }
           });
         }
         if (typeof initMediaCardHover === 'function') {

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -485,31 +485,16 @@
           const body = card.querySelector('.media-card-body');
           if (!title || !body) return;
 
-          // Measure expanded state: temporarily expand title to 3 lines and show year
-          title.style.webkitLineClamp = '3';
           let yearHeight = 0;
           if (year) {
             year.style.display = 'block';
             year.style.opacity = '1';
             yearHeight = year.offsetHeight;
-          }
-
-          // Force reflow to get accurate measurements
-          const expandedTitleHeight = title.scrollHeight;
-          const initialTitleHeight = title.offsetHeight;
-
-          // Reset
-          title.style.webkitLineClamp = '';
-          if (year) {
             year.style.display = '';
             year.style.opacity = '';
           }
 
-          // Calculate extra height: additional title lines + year
-          const extraTitleHeight = Math.max(0, expandedTitleHeight - initialTitleHeight);
-          const extraHeight = extraTitleHeight + yearHeight;
-
-          card.style.setProperty('--year-height', extraHeight + 'px');
+          card.style.setProperty('--year-height', yearHeight + 'px');
         });
       }
 

--- a/src/templates/base_public.html
+++ b/src/templates/base_public.html
@@ -142,31 +142,16 @@
           const body = card.querySelector('.media-card-body');
           if (!title || !body) return;
 
-          // Measure expanded state: temporarily expand title to 3 lines and show year
-          title.style.webkitLineClamp = '3';
           let yearHeight = 0;
           if (year) {
             year.style.display = 'block';
             year.style.opacity = '1';
             yearHeight = year.offsetHeight;
-          }
-
-          // Force reflow to get accurate measurements
-          const expandedTitleHeight = title.scrollHeight;
-          const initialTitleHeight = title.offsetHeight;
-
-          // Reset
-          title.style.webkitLineClamp = '';
-          if (year) {
             year.style.display = '';
             year.style.opacity = '';
           }
 
-          // Calculate extra height: additional title lines + year
-          const extraTitleHeight = Math.max(0, expandedTitleHeight - initialTitleHeight);
-          const extraHeight = extraTitleHeight + yearHeight;
-
-          card.style.setProperty('--year-height', extraHeight + 'px');
+          card.style.setProperty('--year-height', yearHeight + 'px');
         });
       }
 


### PR DESCRIPTION
## Summary
- Hidden titles on cards: the card's slide-up distance wrongly included the title's height, pushing longer titles off the bottom so nothing showed until hover. **Fixed by basing it only on the subtitle height.**

  _Pre-fix behavior_
  
  https://github.com/user-attachments/assets/775fd3f9-9c79-4292-9a17-876a0e0b8c9c



  While working on this fix, I noticed one more issue. Saved books using OpenLibrary as their metadata source were not showing the publish date in the subtitle (see below video for example). Was able to determine that dates with short months like "Sep 27, 2016" weren't being parsed, so the year never saved and thus cards showed no date. **I added those date formats to the parser so they are saved properly now.** It's only a few additional lines of code and it felt like it fell under the scope of these UI changes, but I can separate it into a different PR if desired.

- Disappearing subtitle: when no year resolved, the card deleted the whole subtitle line and lost the reading progress with it. **Fixed by keeping the progress text instead of deleting it outright.**

  _Pre-fix behavior (demonstrates 'missing date' issue as well as 'disappearing subtitle' issue. note difference between saved item and online item, direct from Open Library)_
  
  https://github.com/user-attachments/assets/792f3e02-e437-4a95-9c10-bcd04e662d65

---
Didn't include post-fix videos/screenshots because it is now working as expected, mirroring a typical media card. I can include if desired.

## Notes
**Code written with the help of Claude Opus.**