### PR TITLE
Plex scrobble creating duplicate seasons

### DIFF
--- a/src/app/models/tv.py
+++ b/src/app/models/tv.py
@@ -230,7 +230,11 @@ class TV(Media):
                 media_id=self.item.media_id,
                 source=self.item.source,
                 media_type=MediaTypes.SEASON.value,
-                library_media_type=self.item.library_media_type,
+                library_media_type=(
+                    MediaTypes.ANIME.value
+                    if self.item.library_media_type == MediaTypes.ANIME.value
+                    else MediaTypes.SEASON.value
+                ),
                 season_number=season_number,
                 defaults={
                     **Item.title_fields_from_metadata(
@@ -333,7 +337,11 @@ class TV(Media):
                         media_id=self.item.media_id,
                         source=self.item.source,
                         media_type=MediaTypes.SEASON.value,
-                        library_media_type=self.item.library_media_type,
+                        library_media_type=(
+                            MediaTypes.ANIME.value
+                            if self.item.library_media_type == MediaTypes.ANIME.value
+                            else MediaTypes.SEASON.value
+                        ),
                         season_number=season_data["season_number"],
                         defaults={
                             **Item.title_fields_from_metadata(


### PR DESCRIPTION
## Summary
Previously, TV episodes scrobbled from Plex could show up correctly in History and on the home screen ("15/28 watched"), but when you opened a show and clicked into a season, none of the episodes were marked as watched and the season showed "0/10" - even though the activity history clearly showed when you watched each one.

Was able to determine that Yamtrack had created duplicate seasons. When TV.save() runs its status transitions (completing a season, starting the next one), it was creating Season metadata items using the show's own library bucket (tv) instead of the season bucket that the webhook and every other tracking path use. That meant each season ended up with two records: the real one holding all the episodes (season bucket), and an empty duplicate (tv bucket). The home screen adds up the numbers from all seasons so its count stayed correct, but the season detail page just grabs the first matching record and was landing on the empty duplicate.

## Screenshots of issue

Duplicate seasons - one tracking episodes properly, one not           |
:-------------------------:|
![](https://github.com/user-attachments/assets/c030893c-de54-4c00-b6ce-83ff28031e21)  |

View of show from home screen           |  Show from season detail page
:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/ccc6f1a6-f71b-474b-8192-75573eb4e3a2)  |  ![](https://github.com/user-attachments/assets/86a0f65c-c59f-4d11-aecf-5e417be5a572)


