### PR TITLE
fix(home): sort shows by air date when next episode opens an untracked season

### DIFF
--- a/src/app/models/manager.py
+++ b/src/app/models/manager.py
@@ -576,6 +576,29 @@ class MediaManager(models.Manager):
                 candidates.extend(_ordered_episodes_for_related(season))
 
             if progress_index >= len(candidates):
+                # Seasons not started yet have no Season row, so their calendar
+                # events are invisible above — without them a show whose next
+                # episode opens an untracked season gets no air date and sorts
+                # into the no-date tail.
+                tracked_season_numbers = {
+                    season.item.season_number
+                    for season in seasons
+                    if getattr(season, "item", None) is not None
+                }
+                untracked_events = (
+                    events.models.Event.objects.filter(
+                        item__media_id=item.media_id,
+                        item__source=item.source,
+                        item__media_type=MediaTypes.SEASON.value,
+                        item__season_number__gt=0,
+                        content_number__isnull=False,
+                    )
+                    .exclude(item__season_number__in=tracked_season_numbers)
+                    .order_by("item__season_number", "content_number")
+                )
+                candidates.extend(untracked_events)
+
+            if progress_index >= len(candidates):
                 return None
 
             candidate = candidates[progress_index]

--- a/src/app/tests/views/test_media_list.py
+++ b/src/app/tests/views/test_media_list.py
@@ -14,6 +14,7 @@ from app.models import (
     Anime,
     Artist,
     ArtistTracker,
+    BasicMedia,
     Book,
     Comic,
     ComicIssue,
@@ -1956,6 +1957,37 @@ class MediaListViewTests(TestCase):
             season_response,
             timezone.localtime(future_release).date().isoformat(),
         )
+
+    def test_tv_next_episode_air_date_uses_untracked_season_events(self):
+        """Fall back to untracked-season events when tracked seasons are exhausted."""
+        base_now = timezone.now().replace(hour=12, minute=0, second=0, microsecond=0)
+        season1_release = base_now - timedelta(days=30)
+        season2_release = base_now - timedelta(days=3)
+
+        tv, _season = self._create_tv_next_episode_air_date_entry(
+            "tv-next-episode-untracked",
+            "Untracked Season TV",
+            [season1_release, season1_release + timedelta(days=7)],
+            progress=2,
+        )
+
+        untracked_season_item = Item.objects.create(
+            media_id="tv-next-episode-untracked",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.SEASON.value,
+            title="Untracked Season TV Season 2",
+            image="http://example.com/tv-next-episode-season2.jpg",
+            season_number=2,
+        )
+        Event.objects.create(
+            item=untracked_season_item,
+            content_number=1,
+            datetime=season2_release,
+            notification_sent=False,
+        )
+
+        air_date = BasicMedia.objects._next_episode_air_date_value(tv)
+        self.assertEqual(air_date, season2_release)
 
     def test_anime_sort_by_next_episode_air_date_orders_grouped_and_flat_rows(self):
         self.user.date_format = "iso_8601"


### PR DESCRIPTION
## Problem

On home rows sorted by **Episode Air Date**, a show whose next unwatched episode belongs to a season the user hasn't started yet sorts into the no-date tail at the far end of the row — even when that episode already aired.

`_next_episode_air_date_value` builds its episode-candidate list only from tracked `Season` rows (`media.seasons`). When all tracked-season episodes are watched, the progress index runs off the end of the list and the function returns `None`, so the show is treated as having no upcoming episode.

Real example: House of the Dragon with S1+S2 completed (18 episodes) and S3 airing but untracked — its calendar events for S3 exist on the season `Item`, but the sort never sees them, so the show lands after every dated entry instead of at the front of the row.

## Fix

When the progress index exhausts the tracked-season candidates, fall back to querying calendar `Event` rows for the show's untracked season Items (season > 0, ordered by season/episode number) and extend the candidate list. The extra query runs only in that exhausted case, so the common sort path is unchanged.

## Validation

- New test: `test_tv_next_episode_air_date_uses_untracked_season_events` (all tracked episodes watched + untracked season with an event → returns that event's air date).
- Existing TV/season and anime Episode Air Date sort tests pass.
- `ruff check`: no new findings.

## Remaining edge

If an untracked season sits *between* tracked ones (e.g. S1 and S3 tracked, S2 not), its events are appended after the tracked candidates rather than interleaved, so the index can pick a slightly off episode — that case was already misordered before this change.