### PR TITLE
fix(home): show Next ep button for flat anime and untracked next seasons

### DIFF
--- a/src/app/templatetags/app_tags.py
+++ b/src/app/templatetags/app_tags.py
@@ -900,6 +900,55 @@ def media_url(media):
     )
 
 
+def _untracked_season_next_episode_url(item, seasons, actual_media_type):
+    """Return the first-episode URL of the next untracked season, if known.
+
+    When every tracked season is complete the next unwatched episode lives in a
+    season without a Season row. Untracked seasons are only visible through
+    their calendar events (same source as _next_episode_air_date_value).
+    """
+    from events.models import Event
+
+    is_dict = isinstance(item, dict)
+    media_id = item["media_id"] if is_dict else getattr(item, "media_id", None)
+    source = item["source"] if is_dict else getattr(item, "source", None)
+    if not media_id or not source:
+        return ""
+
+    tracked_season_numbers = {
+        season.item.season_number
+        for season in seasons.all()
+        if getattr(season, "item", None) is not None
+    }
+    event = (
+        Event.objects.filter(
+            item__media_id=media_id,
+            item__source=source,
+            item__media_type=MediaTypes.SEASON.value,
+            item__season_number__gt=0,
+            content_number__isnull=False,
+        )
+        .exclude(item__season_number__in=tracked_season_numbers)
+        .order_by("item__season_number", "content_number")
+        .select_related("item")
+        .first()
+    )
+    if event is None:
+        return ""
+
+    title = item["title"] if is_dict else getattr(item, "title", "")
+    slug_title = slug(title) or slug(str(media_id)) or "item"
+    is_anime = actual_media_type == MediaTypes.ANIME.value
+    url_name = "anime_episode_details" if is_anime else "episode_details"
+    return reverse(url_name, kwargs={
+        "source": source,
+        "media_id": media_id,
+        "title": slug_title,
+        "season_number": event.item.season_number,
+        "episode_number": event.content_number,
+    })
+
+
 @register.simple_tag
 def next_episode_url(item, media):
     """Return the episode detail URL for the next unwatched episode.
@@ -941,6 +990,21 @@ def next_episode_url(item, media):
     if actual_media_type in (MediaTypes.TV.value, MediaTypes.ANIME.value):
         seasons = getattr(media, "seasons", None)
         if not media or seasons is None:
+            # Flat MAL anime has no seasons — resolve the provider mapping at
+            # click time via the redirect view instead of per card at render.
+            source = item["source"] if is_dict else getattr(item, "source", None)
+            media_id = item["media_id"] if is_dict else getattr(item, "media_id", None)
+            if (
+                actual_media_type == MediaTypes.ANIME.value
+                and source == Sources.MAL.value
+                and media_id
+            ):
+                title = item["title"] if is_dict else getattr(item, "title", "")
+                slug_title = slug(title) or slug(str(media_id)) or "item"
+                return reverse(
+                    "anime_next_episode",
+                    kwargs={"media_id": media_id, "title": slug_title},
+                )
             return ""
         # Seasons are already prefetched for TV home cards — no extra query
         in_progress = [
@@ -949,7 +1013,7 @@ def next_episode_url(item, media):
             and getattr(getattr(s, "item", None), "season_number", 0) != 0
         ]
         if not in_progress:
-            return ""
+            return _untracked_season_next_episode_url(item, seasons, actual_media_type)
         season = min(in_progress, key=lambda s: s.item.season_number)
         season_item = season.item
         slug_title = slug(season_item.title) or slug(str(season_item.media_id)) or "item"

--- a/src/app/tests/test_templatetags.py
+++ b/src/app/tests/test_templatetags.py
@@ -884,3 +884,116 @@ class AppTagsTests(TestCase):
         self.assertTrue(app_tags.show_media_score(1, mock_user_hide))
         self.assertFalse(app_tags.show_media_score(0, mock_user_hide))
         self.assertFalse(app_tags.show_media_score(None, mock_user_hide))
+
+
+class NextEpisodeUrlTests(TestCase):
+    """Test the next_episode_url template tag."""
+
+    def setUp(self):
+        """Set up a user for tracked media."""
+        self.user = get_user_model().objects.create_user(
+            username="nextep",
+            password="12345",
+        )
+
+    def _create_tv_with_completed_season(self, media_id="1668", progress=8):
+        """Return a TV show whose only tracked season is completed."""
+        from app.models import TV, Season, Status
+
+        tv_item = Item.objects.create(
+            media_id=media_id,
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Untracked Next Season TV",
+            image="http://example.com/tv.jpg",
+        )
+        tv = TV.objects.create(
+            item=tv_item,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+        )
+        season_item = Item.objects.create(
+            media_id=media_id,
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.SEASON.value,
+            title="Untracked Next Season TV",
+            image="http://example.com/tv-s1.jpg",
+            season_number=1,
+        )
+        Season.objects.create(
+            item=season_item,
+            user=self.user,
+            related_tv=tv,
+            status=Status.COMPLETED.value,
+        )
+        return tv_item, tv
+
+    def test_tv_show_falls_back_to_untracked_season_events(self):
+        """Link the first event episode of the next untracked season."""
+        from events.models import Event
+
+        tv_item, tv = self._create_tv_with_completed_season()
+        untracked_season_item = Item.objects.create(
+            media_id="1668",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.SEASON.value,
+            title="Untracked Next Season TV",
+            image="http://example.com/tv-s2.jpg",
+            season_number=2,
+        )
+        Event.objects.create(
+            item=untracked_season_item,
+            content_number=1,
+            datetime=timezone.now(),
+            notification_sent=False,
+        )
+
+        url = app_tags.next_episode_url(tv_item, tv)
+
+        self.assertEqual(
+            url,
+            reverse(
+                "episode_details",
+                kwargs={
+                    "source": Sources.TMDB.value,
+                    "media_id": "1668",
+                    "title": "untracked-next-season-tv",
+                    "season_number": 2,
+                    "episode_number": 1,
+                },
+            ),
+        )
+
+    def test_tv_show_without_untracked_events_returns_empty(self):
+        """No fallback URL when the untracked season has no events."""
+        tv_item, tv = self._create_tv_with_completed_season()
+
+        self.assertEqual(app_tags.next_episode_url(tv_item, tv), "")
+
+    def test_flat_mal_anime_links_next_episode_redirect(self):
+        """Flat MAL anime cards link the click-time resolver endpoint."""
+        from app.models import Anime, Status
+
+        anime_item = Item.objects.create(
+            media_id="51553",
+            source=Sources.MAL.value,
+            media_type=MediaTypes.ANIME.value,
+            title="Witch Hat Atelier",
+            image="http://example.com/anime.jpg",
+        )
+        anime = Anime.objects.create(
+            item=anime_item,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+            progress=3,
+        )
+
+        url = app_tags.next_episode_url(anime_item, anime)
+
+        self.assertEqual(
+            url,
+            reverse(
+                "anime_next_episode",
+                kwargs={"media_id": "51553", "title": "witch-hat-atelier"},
+            ),
+        )

--- a/src/app/tests/views/test_media_details.py
+++ b/src/app/tests/views/test_media_details.py
@@ -7402,3 +7402,80 @@ class MediaDetailsViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         item.refresh_from_db()
         self.assertEqual(item.image, existing_image)
+
+
+class AnimeNextEpisodeRedirectTests(TestCase):
+    """Test the anime_next_episode click-time redirect view."""
+
+    def setUp(self):
+        self.credentials = {"username": "nextep", "password": "12345"}
+        self.user = get_user_model().objects.create_user(**self.credentials)
+        self.client.login(**self.credentials)
+        self.item = Item.objects.create(
+            media_id="51553",
+            source=Sources.MAL.value,
+            media_type=MediaTypes.ANIME.value,
+            title="Witch Hat Atelier",
+            image="http://example.com/anime.jpg",
+        )
+        Anime.objects.create(
+            item=self.item,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+            progress=3,
+        )
+        self.url = reverse(
+            "anime_next_episode",
+            kwargs={"media_id": "51553", "title": "witch-hat-atelier"},
+        )
+        self.detail_url = reverse(
+            "media_details",
+            kwargs={
+                "source": Sources.MAL.value,
+                "media_type": MediaTypes.ANIME.value,
+                "media_id": "51553",
+                "title": "witch-hat-atelier",
+            },
+        )
+
+    @patch("app.views._build_flat_anime_episode_preview")
+    @patch("app.views.services.get_media_metadata")
+    def test_redirects_to_mapped_next_episode(self, mock_metadata, mock_preview):
+        mock_metadata.return_value = {"title": "Witch Hat Atelier", "details": {}}
+        mock_preview.return_value = [
+            {
+                "source": Sources.TMDB.value,
+                "media_id": "241259",
+                "season_number": 1,
+                "episode_number": episode_number,
+                "display_episode_number": episode_number,
+            }
+            for episode_number in range(1, 6)
+        ]
+
+        response = self.client.get(self.url)
+
+        self.assertRedirects(
+            response,
+            reverse(
+                "anime_episode_details",
+                kwargs={
+                    "source": Sources.TMDB.value,
+                    "media_id": "241259",
+                    "title": "witch-hat-atelier",
+                    "season_number": 1,
+                    "episode_number": 4,
+                },
+            ),
+            fetch_redirect_response=False,
+        )
+
+    @patch("app.views._build_flat_anime_episode_preview")
+    @patch("app.views.services.get_media_metadata")
+    def test_falls_back_to_detail_page_without_mapping(self, mock_metadata, mock_preview):
+        mock_metadata.return_value = {"title": "Witch Hat Atelier", "details": {}}
+        mock_preview.return_value = None
+
+        response = self.client.get(self.url)
+
+        self.assertRedirects(response, self.detail_url, fetch_redirect_response=False)

--- a/src/app/urls.py
+++ b/src/app/urls.py
@@ -53,6 +53,11 @@ urlpatterns = [
         name="anime_season_details",
     ),
     path(
+        "details/mal/anime/<str:media_id>/<str:title>/next-episode",
+        views.anime_next_episode,
+        name="anime_next_episode",
+    ),
+    path(
         "details/<source:source>/<media_type:media_type>/<path:media_id>/<str:title>",
         views.media_details,
         name="media_details",

--- a/src/app/views.py
+++ b/src/app/views.py
@@ -607,6 +607,90 @@ def episode_details(request, source, media_id, title, season_number, episode_num
     }
     return render(request, "app/episode_details.html", context)
 
+
+@never_cache
+@require_GET
+def anime_next_episode(request, media_id, title):
+    """Redirect a flat MAL anime to its next unwatched mapped episode page.
+
+    Home cards can't resolve the MAL→provider mapping per card at render time,
+    so this resolves it once at click time and falls back to the anime detail
+    page when no mapping (or no next episode) exists.
+    """
+    detail_url = reverse(
+        "media_details",
+        kwargs={
+            "source": Sources.MAL.value,
+            "media_type": MediaTypes.ANIME.value,
+            "media_id": media_id,
+            "title": title,
+        },
+    )
+    if not request.user.is_authenticated:
+        return redirect(detail_url)
+
+    anime = Anime.objects.filter(
+        user=request.user,
+        item__media_id=media_id,
+        item__source=Sources.MAL.value,
+        item__media_type=MediaTypes.ANIME.value,
+    ).first()
+    progress = int(anime.progress or 0) if anime else 0
+
+    detail_item = Item.objects.filter(
+        media_id=media_id,
+        source=Sources.MAL.value,
+        media_type=MediaTypes.ANIME.value,
+    ).first()
+
+    try:
+        base_metadata = services.get_media_metadata(
+            MediaTypes.ANIME.value,
+            media_id,
+            Sources.MAL.value,
+        )
+    except Exception:
+        return redirect(detail_url)
+
+    try:
+        preview_episodes = _build_flat_anime_episode_preview(
+            request,
+            detail_item=detail_item,
+            media_id=media_id,
+            base_metadata=base_metadata,
+        ) or []
+    except Exception:
+        logger.warning(
+            "Failed to resolve next-episode mapping for MAL anime %s",
+            media_id,
+            exc_info=True,
+        )
+        preview_episodes = []
+
+    next_ep = next(
+        (
+            ep for ep in preview_episodes
+            if ep.get("display_episode_number") == progress + 1
+        ),
+        None,
+    )
+    if not next_ep:
+        return redirect(detail_url)
+
+    return redirect(
+        reverse(
+            "anime_episode_details",
+            kwargs={
+                "source": next_ep["source"],
+                "media_id": next_ep["media_id"],
+                "title": title,
+                "season_number": next_ep["season_number"],
+                "episode_number": next_ep["episode_number"],
+            },
+        ),
+    )
+
+
 @require_POST
 def music_bulk_save(request):
     """Dispatch a bulk music play range as a background task and return immediately."""


### PR DESCRIPTION
## Summary

On the Home page, the "Next ep" quick-link chip was missing from two kinds of in-progress cards:

- **Flat MAL anime cards** (the whole Anime row): `next_episode_url` expected `media.seasons`, which the flat `Anime` model doesn't have, so it always returned nothing. The underlying problem is that building the episode URL needs the MAL→TMDB/TVDB mapping, which is too expensive to resolve per card at render time.
- **TV/anime show cards whose next episode opens an untracked season** (e.g. Pantheon at S1 complete with S2 unstarted, House of the Dragon): the tag only linked when a *tracked* season was in progress, so shows with all tracked seasons complete got no button — the same root cause as the air-date sorting gap fixed in b2f10af.

## Changes

- `next_episode_url` now falls back to the first calendar-event episode of the next untracked season, using the same Events data `_next_episode_air_date_value` uses.
- Flat MAL anime cards link a new `anime_next_episode` endpoint (`details/mal/anime/<id>/<title>/next-episode`) that resolves the provider mapping once at click time via `_build_flat_anime_episode_preview` and redirects to the mapped episode page — correctly handling cross-season mappings. Unmapped titles fall back to the anime detail page.

## Validation

- 5 new tests (3 template-tag, 2 redirect-view), all passing.
- `manage.py check` clean; home view tests show only failures that also fail on the base branch.

Note: the untracked-season fallback depends on calendar events existing for that season — the same condition under which the show sorts correctly in "Episode Air Date" rows.