### PR TITLE
Fix errant dates for some TV seasons

### DIFF
--- a/src/app/metadata_utils.py
+++ b/src/app/metadata_utils.py
@@ -207,6 +207,7 @@ def apply_item_metadata(
         include_release
         and values["release_datetime"]
         and item.release_datetime != values["release_datetime"]
+        and item.media_type != MediaTypes.SEASON.value
     ):
         item.release_datetime = values["release_datetime"]
         update_fields.append("release_datetime")

--- a/src/app/season_details_views.py
+++ b/src/app/season_details_views.py
@@ -522,7 +522,10 @@ def season_details(
         for episode in season_metadata["episodes"]:
             episode_number = episode.get("episode_number")
             episode["collection_entry"] = collection_entries.get(episode_number)
-            episode["item"] = item_by_episode_number.get(episode_number)
+            db_item = item_by_episode_number.get(episode_number)
+            episode["item"] = db_item
+            if db_item is not None and db_item.release_datetime is not None:
+                episode["air_date"] = db_item.release_datetime
 
     # Enrich related items with user tracking data
     # For public views, use list owner's data if available

--- a/src/events/calendar/tv.py
+++ b/src/events/calendar/tv.py
@@ -151,7 +151,11 @@ def process_tv_seasons(tv_item, seasons_to_process, events_bulk):
                     season_metadata,
                     fallback_title=tv_item.title,
                 ),
-                "library_media_type": tv_item.library_media_type,
+                "library_media_type": (
+                    MediaTypes.ANIME.value
+                    if tv_item.library_media_type == MediaTypes.ANIME.value
+                    else MediaTypes.SEASON.value
+                ),
                 "image": season_image,
             },
         )
@@ -345,6 +349,7 @@ def process_season_episodes(item, metadata, events_bulk):
     }
     items_to_update = []
     new_items = []
+    earliest_release = None
 
     for episode in metadata["episodes"]:
         episode_number = episode["episode_number"]
@@ -379,7 +384,12 @@ def process_season_episodes(item, metadata, events_bulk):
                 media_type=MediaTypes.EPISODE.value,
                 title=item.title,
                 image=image,
-                library_media_type=item.library_media_type,
+                library_media_type=(
+                    item.library_media_type
+                    if item.library_media_type
+                    and item.library_media_type != MediaTypes.SEASON.value
+                    else MediaTypes.EPISODE.value
+                ),
                 season_number=season_number,
                 episode_number=episode_number,
             )
@@ -387,6 +397,11 @@ def process_season_episodes(item, metadata, events_bulk):
             new_items.append(episode_item)
 
         release_datetime = episode_datetime if episode_datetime.year > 1900 else None
+
+        if release_datetime is not None and (
+            earliest_release is None or release_datetime < earliest_release
+        ):
+            earliest_release = release_datetime
 
         runtime_minutes = None
         if episode.get("runtime") is not None:
@@ -417,7 +432,13 @@ def process_season_episodes(item, metadata, events_bulk):
             batch_size=100,
         )
 
-    return bool(new_items or items_to_update)
+    season_release_updated = False
+    if earliest_release is not None and item.release_datetime != earliest_release:
+        item.release_datetime = earliest_release
+        item.save(update_fields=["release_datetime"])
+        season_release_updated = True
+
+    return bool(new_items or items_to_update or season_release_updated)
 
 
 def get_episode_datetime(episode, season_number, episode_number, tvmaze_map):


### PR DESCRIPTION
## Summary

Noticed the release/air dates were off by a day for a few upcoming TV show seasons (Silo S3, Ted Lasso S4, Slow Horses S6). The dates were coming from TMDB, but the accurate TVMaze data was already being pulled into the calendar, just not used in a couple of places.

Fixed it to use the TVMaze dates that were already there:

- Season detail page - episode air dates now use the episode's stored release_datetime (TVMaze) instead of TMDB's air_date.
- Season library / home upcoming - the season's own release date now comes from the first episode's TVMaze date. The calendar writes it onto the season item when it processes events, and I added a guard so the metadata backfill stops overwriting it back to TMDB.

_**TVMaze Source of truth** (can also confirm that Silo s3 is literally not out yet, despite TMDB date)_
<img width="1249" height="586" alt="Screenshot 2026-07-02 at 8 57 37 PM" src="https://github.com/user-attachments/assets/9d3ff1b1-e265-4829-89aa-676a6ddde4dc" />


_**TV Season in library view**_
Before             |  After
:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/bffad6da-8ed0-4e74-9900-fb2c3b4483bc)  |  ![](https://github.com/user-attachments/assets/73fd0e54-7686-46d6-81d2-74a8f7ea368d)

_**Episode list in season detail view**_
Before             |  After
:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/b21d1df8-02d8-42ba-984b-b17f7ccaa3dd)  |  ![](https://github.com/user-attachments/assets/d5ded68b-b4a0-4954-99ea-b09233c3f854)

_Additional cleanup_
One other issue I noticed while working in tv.py. The calendar was creating season and episode items using the tv bucket instead of season/episode (same problem that was fixed in #302). Only required a couple of lines to fix - see 154-158 and 387-392.


## Notes
**Code written with the help of Claude Opus.**
