### PR TITLE
Fix regression related to season number mismatches

### DIFF
--- a/src/events/calendar/tv.py
+++ b/src/events/calendar/tv.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
 import requests
@@ -446,12 +446,10 @@ def get_episode_datetime(episode, season_number, episode_number, tvmaze_map):
     tvmaze_key = f"{season_number}_{episode_number}"
     tvmaze_airstamp = tvmaze_map.get(tvmaze_key)
 
-    if tvmaze_airstamp:
-        return datetime.fromisoformat(tvmaze_airstamp)
-
-    if episode["air_date"]:
+    tmdb_datetime = None
+    if episode.get("air_date"):
         try:
-            return date_parser(episode["air_date"])
+            tmdb_datetime = date_parser(episode["air_date"])
         except ValueError:
             logger.warning(
                 "Invalid air date for S%sE%s from TMDB: %s",
@@ -459,6 +457,17 @@ def get_episode_datetime(episode, season_number, episode_number, tvmaze_map):
                 episode_number,
                 episode["air_date"],
             )
+
+    if tvmaze_airstamp:
+        tvmaze_datetime = datetime.fromisoformat(tvmaze_airstamp)
+        if tmdb_datetime is None or abs(tvmaze_datetime - tmdb_datetime) <= timedelta(
+            days=2,
+        ):
+            return tvmaze_datetime
+        return tmdb_datetime
+
+    if tmdb_datetime is not None:
+        return tmdb_datetime
 
     return datetime.min.replace(tzinfo=ZoneInfo("UTC"))
 


### PR DESCRIPTION
## Summary
Noticed one regression related to #312 during my testing. For the Netflix show Lupin, which uses Part 1/2/3/4 season numbering, there was a mismatch between [TMDB](https://www.themoviedb.org/tv/96677-lupin/season/3) (which combined Parts 1 and 2 into a single season) and [TVMaze](https://www.tvmaze.com/seasons/185629/lupin-season-4) (which kept each part as its own season). The result was that Yamtrack was showing incorrect dates for all seasons after 2.

Thus, made a change so we trust TVMaze's more precise air date only when it's within a couple days of what TMDB reports.


_**Release Date via TVMaze (TMDB calls it S3, TVM calls it S4)**_
<img width="499" height="249" alt="Screenshot 2026-07-03 at 2 34 07 PM" src="https://github.com/user-attachments/assets/f325d7e5-62aa-40e4-be9a-d1d5b482bd09" />

_**Date mismatch**_
Before             |  After
:-------------------------:|:-------------------------:
 ![](https://github.com/user-attachments/assets/0053e859-2e5d-4af0-8b62-565f28a493ab) | ![](https://github.com/user-attachments/assets/2096efec-99a1-4687-b1f8-8b78293885ad) 

 

## Notes
**Code written with the help of Claude Opus.**
