### PR TITLE
Fix missing subtitle on podcast hover

### DIFF
--- a/src/app/media_list_views.py
+++ b/src/app/media_list_views.py
@@ -1845,6 +1845,10 @@ def media_list(request, media_type):
                 self.updated_at = tracker.updated_at
                 self.release_datetime = getattr(tracker, "first_published", None)
 
+                # Reuse the home music card subtitle slot to show the author
+                self.home_music_card = True
+                self.card_subtitle_text = tracker.show.author or ""
+
                 # Create a mock Item for compatibility with media components
                 # Use the show's podcast_uuid as media_id for routing
                 self.item, _ = Item.objects.get_or_create(

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -476,7 +476,7 @@
     <script>
       // Media card hover - slide body up to reveal expanded title + year
       function initMediaCardHover() {
-        document.querySelectorAll('.search-result-card').forEach(card => {
+        document.querySelectorAll('.search-result-card, .search-result-card-square').forEach(card => {
           if (card.dataset.hoverInit) return;
           card.dataset.hoverInit = 'true';
 

--- a/src/templates/base_public.html
+++ b/src/templates/base_public.html
@@ -133,7 +133,7 @@
     <script>
       // Media card hover - slide body up to reveal expanded title + year
       function initMediaCardHover() {
-        document.querySelectorAll('.search-result-card').forEach(card => {
+        document.querySelectorAll('.search-result-card, .search-result-card-square').forEach(card => {
           if (card.dataset.hoverInit) return;
           card.dataset.hoverInit = 'true';
 


### PR DESCRIPTION
## Summary
Podcast cards had no subtitle, but the layout still shifted the text down to make room for one. 
- Added the show's author as the podcast card subtitle
- Fixed the layout so the title stays visible, even if the podcast doesn't have an author for some reason

_**Before**_
Default             |  On hover
:-------------------------:|:-------------------------:
 ![](https://github.com/user-attachments/assets/8c5aabba-3aca-41fb-8d2b-27ce5eb8d8a8) | ![](https://github.com/user-attachments/assets/efb6a149-47ee-4995-b3d7-a360aed0ef0a) 

_**After**_
Default             |  On hover
:-------------------------:|:-------------------------:
 ![](https://github.com/user-attachments/assets/3ed3399d-e209-4a65-bf79-442d594100ec) | ![](https://github.com/user-attachments/assets/07ee383f-f1bb-4dd3-84ed-5e54de4e8e4d) 


## Notes
**Code written with the help of Claude Opus.**
