### PR TITLE
Add dedicated discover celery queue and bump recurring import priority

### DIFF
--- a/src/app/tasks_discover.py
+++ b/src/app/tasks_discover.py
@@ -115,6 +115,14 @@ def refresh_discover_tab_cache(
     }
 
 
+# Maximum discover tab tasks enqueued in a single startup warmup. After a
+# Redis restart all freshness locks are gone, so without this cap every user ×
+# every media type would be enqueued at once, burying the celery queue.
+# Users whose tabs are not pre-warmed receive them on first page load via the
+# request-time warmup path (maybe_schedule_user_warmup).
+STARTUP_WARMUP_TASK_LIMIT = 50
+
+
 @shared_task(name="Warm Discover Startup Tabs")
 def warm_discover_startup_tabs(user_ids: list[int] | None = None):
     """Warm the default Discover tab cache for users after app startup."""
@@ -129,6 +137,8 @@ def warm_discover_startup_tabs(user_ids: list[int] | None = None):
     scheduled = 0
     users_count = 0
     for user in users.iterator(chunk_size=200):
+        if scheduled >= STARTUP_WARMUP_TASK_LIMIT:
+            break
         users_count += 1
         scheduled += schedule_user_tab_warmup(
             user,

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -1042,6 +1042,9 @@ CELERY_TASK_ROUTES = {
     # Long-running scheduled tasks — low priority so beat-catch-up bursts don't
     # starve other celery-queue work.
     "Reload calendar": {"priority": CELERY_TASK_PRIORITY_BACKGROUND},
+    # Discover cache rebuilds go to the dedicated discover worker so a post-restart
+    # burst of O(users x tabs) tasks never starves imports or background work.
+    "Refresh Discover Tab Cache": {"queue": "discover"},
     # User-triggered cache rebuilds go to the dedicated interactive worker so they
     # are never blocked behind long-running background tasks.
     "app.tasks.refresh_statistics_cache_task": {"queue": "interactive"},
@@ -1052,6 +1055,15 @@ CELERY_TASK_ROUTES = {
         "queue": "interactive",
         "priority": CELERY_TASK_PRIORITY_INTERACTIVE,
     },
+    # Recurring imports are time-sensitive (every 2 h) — bump above generic
+    # background tasks so a backlog of low-priority work doesn't delay them.
+    "Import from Radarr (Recurring)": {"priority": CELERY_TASK_PRIORITY_FOLLOWUP},
+    "Import from Sonarr (Recurring)": {"priority": CELERY_TASK_PRIORITY_FOLLOWUP},
+    "Import from Audiobookshelf (Recurring)": {
+        "priority": CELERY_TASK_PRIORITY_FOLLOWUP,
+    },
+    "Import from Pocket Casts (Recurring)": {"priority": CELERY_TASK_PRIORITY_FOLLOWUP},
+    "Import from GPodder (Recurring)": {"priority": CELERY_TASK_PRIORITY_FOLLOWUP},
 }
 
 

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -44,6 +44,18 @@ stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stdout
 stderr_logfile_maxbytes=0
 
+[program:celery-discover]
+command=sh -c 'if [ "${ENV_DEBUG:-False}" = "True" ]; then LOGLEVEL=DEBUG; else LOGLEVEL=INFO; fi; celery --app config worker --queues discover --hostname=celery-discover@%%h --loglevel $LOGLEVEL --without-mingle --without-gossip'
+environment=YAMTRACK_PROCESS_ROLE="background"
+user=abc
+stopasgroup=true
+stopwaitsecs=60
+priority=10
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stdout
+stderr_logfile_maxbytes=0
+
 [program:celery-beat]
 command=sh -c 'sleep 8; if [ "${ENV_DEBUG:-False}" = "True" ]; then LOGLEVEL=DEBUG; else LOGLEVEL=INFO; fi; celery --app config beat --loglevel $LOGLEVEL'
 environment=YAMTRACK_PROCESS_ROLE="background"


### PR DESCRIPTION
## Problem

After a Redis restart, all discover-tab freshness locks are gone, so `warm_discover_startup_tabs` enqueues a `Refresh Discover Tab Cache` task for every user × every media type with no cap — on instances with a meaningful user base this can enqueue hundreds of tasks at once. These previously ran on the shared `celery-queue` worker alongside imports and other background work, so a post-restart warmup burst could delay time-sensitive recurring imports (Radarr/Sonarr/Audiobookshelf/Pocket Casts/GPodder), which run every 2 hours and should not get stuck behind a backlog of low-priority work.

## Solution

- Route `Refresh Discover Tab Cache` to a new dedicated `discover` queue/worker (`celery-discover` in supervisord), isolating discover warmup from imports and other background work.
- Cap `warm_discover_startup_tabs` to 50 scheduled tasks per boot (`STARTUP_WARMUP_TASK_LIMIT`). Users who aren't pre-warmed at startup still get warmed lazily on first page load via the existing request-time path (`maybe_schedule_user_warmup`).
- Bump the five recurring import tasks above generic background priority so a backlog of low-priority work doesn't delay their schedule.

## Validation

- `ruff check` clean on the changed lines in `src/app/tasks_discover.py` and `src/config/settings.py` (pre-existing lint elsewhere in these files left untouched).
- Full `pytest` suite run against this branch: 2070 passed, 128 failed, 8 errors, 2 skipped — all failures/errors reproduce identically on `latest` prior to this change (verified by running the same failing tests against the pre-change commit), confirming no regressions from this PR.
- Manually running this configuration in a self-hosted deployment for several days without discover warmup delaying imports.

## AI Assistance
Generated with Claude Code (claude-sonnet-5). Reviewed and tested manually.