### PR TITLE
Add episode switcher dropdown to episode detail pages

### DIFF
--- a/src/app/views.py
+++ b/src/app/views.py
@@ -649,6 +649,7 @@ def episode_details(request, source, media_id, title, season_number, episode_num
     context = {
         "user": request.user,
         "episode": episode_data,
+        "episodes": processed_episodes,
         "episode_metadata": episode_metadata,
         "season_metadata": season_metadata,
         "current_instance": current_season_instance,

--- a/src/templates/app/episode_details.html
+++ b/src/templates/app/episode_details.html
@@ -75,7 +75,7 @@
                  @keydown.escape.window="open = false">
               <button @click="open = !open"
                       class="flex items-center space-x-2 px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded-md transition-colors duration-200 cursor-pointer">
-                <span class="text-sm font-medium">{{ episode_title }}</span>
+                <span class="text-sm font-medium">{{ episode.display_episode_number|default:episode_number }}. {{ episode_title }}</span>
                 <div class="w-4 h-4" :class="{ 'rotate-180': open }">{% include "app/icons/chevron-down.svg" %}</div>
               </button>
               <div x-show="open"

--- a/src/templates/app/episode_details.html
+++ b/src/templates/app/episode_details.html
@@ -66,6 +66,46 @@
               {% if not public_view and episode and episode.history %}{% with ep_watched=episode.history|watched_count %}{% if ep_watched %}<span class="mx-1 text-gray-600">•</span>Watched {% if ep_watched == 1 %}once{% else %}{{ ep_watched }} times{% endif %}{% endif %}{% endwith %}{% endif %}
             </div>
           </div>
+
+          {# Episode dropdown #}
+          {% if episodes %}
+            <div class="relative hidden md:block"
+                 x-data="{ open: false }"
+                 @click.away="open = false"
+                 @keydown.escape.window="open = false">
+              <button @click="open = !open"
+                      class="flex items-center space-x-2 px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded-md transition-colors duration-200 cursor-pointer">
+                <span class="text-sm font-medium">{{ episode_title }}</span>
+                <div class="w-4 h-4" :class="{ 'rotate-180': open }">{% include "app/icons/chevron-down.svg" %}</div>
+              </button>
+              <div x-show="open"
+                   x-transition:enter="transition ease-out duration-200"
+                   x-transition:enter-start="opacity-0 transform scale-95"
+                   x-transition:enter-end="opacity-100 transform scale-100"
+                   x-transition:leave="transition ease-in duration-150"
+                   x-transition:leave-start="opacity-100 transform scale-100"
+                   x-transition:leave-end="opacity-0 transform scale-95"
+                   class="absolute right-1/2 md:right-0 translate-x-1/2 md:translate-x-0 mt-2 w-64 bg-[#2a2f35] rounded-md shadow-lg overflow-hidden z-10">
+                <div class="max-h-[300px] overflow-y-auto">
+                  {% for ep in episodes %}
+                    <a href="{% if parent_media_type == MediaTypes.ANIME.value %}{% url 'anime_episode_details' source=source media_id=media_id title=show_title|slug season_number=season_number episode_number=ep.episode_number %}{% else %}{% url 'episode_details' source=source media_id=media_id title=show_title|slug season_number=season_number episode_number=ep.episode_number %}{% endif %}"
+                       hx-boost="true"
+                       class="w-full px-4 py-3 flex items-center space-x-3 hover:bg-gray-700 transition-colors duration-200 cursor-pointer {% if ep.episode_number == episode_number %}bg-[#343a40]{% endif %}">
+                      <div class="w-8 h-8 rounded-full flex items-center justify-center bg-indigo-600 text-white shrink-0">
+                        {{ ep.display_episode_number|default:ep.episode_number }}
+                      </div>
+                      <div class="flex-1 text-left min-w-0">
+                        <div class="text-sm font-medium line-clamp-1">{{ ep.title }}</div>
+                        <div class="text-xs text-gray-400">
+                          {{ ep.air_date|user_date_format:user|default_if_none:"Unknown date" }}
+                        </div>
+                      </div>
+                    </a>
+                  {% endfor %}
+                </div>
+              </div>
+            </div>
+          {% endif %}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Season detail pages already have a dropdown for quickly switching between seasons; episode detail pages had no equivalent for switching between episodes of the same season.
- Adds a matching dropdown to `episode_details.html`, listing every episode in the current season (title, air date, episode number), highlighting the current one, and linking to `episode_details`/`anime_episode_details` as appropriate.
- `episode_details` view now passes the season's processed episode list into the template context as `episodes`.
- The collapsed dropdown button shows the episode number alongside the title (e.g. "5. Gray Matter"), matching the numbering shown in the expanded list.

Works across TMDB, TVDB, and anime-flagged shows, since the underlying `processed_episodes` data and anime/non-anime URL branching already handle those cases uniformly (matches the existing pattern in `media_details.html`'s season dropdown).

## Test plan
- [x] `python manage.py check` passes
- [x] Verified in a local Docker build against real TMDB-backed season/episode data — dropdown opens, links to other episodes in the season, current episode highlighted, button label shows number + title