### PR TITLE
Fix completion fan-out when tracking a show/season/anime directly as Completed

### DIFF
--- a/src/app/models/media.py
+++ b/src/app/models/media.py
@@ -16,7 +16,7 @@ from simple_history.models import HistoricalRecords
 
 import app
 from app import providers
-from app.models.choices import MediaTypes, Status
+from app.models.choices import MediaTypes, Sources, Status
 from app.models.item import Item
 from app.models.manager import MediaManager
 
@@ -616,6 +616,87 @@ class Anime(Media):
     tracker = FieldTracker()
     objects = ActiveAnimeManager()
     all_objects = models.Manager()
+
+    def save(self, *args, **kwargs):
+        """Save, then auto-migrate a completed flat MAL anime to episode tracking.
+
+        A flat MAL anime has no per-episode watch records, so completing it would
+        otherwise leave its (provider-mapped) episode list showing unwatched. When
+        it becomes COMPLETED we convert it into grouped TV-style tracking, which
+        creates real Episode records for every watched episode.
+        """
+        is_create = self._state.adding
+        status_changed = self.tracker.has_changed("status")
+        super().save(*args, **kwargs)
+
+        became_completed = self.status == Status.COMPLETED.value and (
+            status_changed or is_create
+        )
+        if (
+            became_completed
+            and self.migrated_to_item_id is None
+            and self.item.source == Sources.MAL.value
+            and self.item.media_type == MediaTypes.ANIME.value
+        ):
+            self._auto_migrate_completed_flat_anime()
+
+    def _auto_migrate_completed_flat_anime(self):
+        """Best-effort migration of a completed flat MAL anime; never fatal."""
+        try:
+            self._migrate_completed_flat_anime()
+        except Exception:
+            logger.warning(
+                "Auto-migrate crashed for MAL anime %s",
+                getattr(self.item, "media_id", None), exc_info=True,
+            )
+
+    def _migrate_completed_flat_anime(self):
+        from app.services import anime_migration, metadata_resolution
+        from integrations import anime_mapping
+
+        providers_to_try = []
+        default_source = (
+            metadata_resolution.metadata_default_source(
+                self.user, MediaTypes.ANIME.value,
+            )
+            if self.user_id
+            else None
+        )
+        for provider in (default_source, Sources.TVDB.value, Sources.TMDB.value):
+            if (
+                provider in metadata_resolution.GROUPED_ANIME_PROVIDERS
+                and metadata_resolution.provider_is_enabled(provider)
+                and provider not in providers_to_try
+            ):
+                providers_to_try.append(provider)
+
+        for provider in providers_to_try:
+            if not anime_mapping.resolve_provider_series_id(
+                self.item.media_id, provider,
+            ):
+                continue
+            try:
+                anime_migration.migrate_flat_anime_to_grouped(
+                    self.user, self.item, provider,
+                )
+            except anime_migration.AnimeMigrationError as error:
+                logger.info(
+                    "Auto-migrate skipped for MAL anime %s via %s: %s",
+                    self.item.media_id, provider, error,
+                )
+                continue
+            except Exception:
+                logger.warning(
+                    "Auto-migrate failed for MAL anime %s via %s",
+                    self.item.media_id, provider, exc_info=True,
+                )
+                return
+            else:
+                logger.info(
+                    "Auto-migrated completed flat MAL anime %s to grouped %s tracking",
+                    self.item.media_id, provider,
+                )
+                return
 
 
 class Movie(Media):

--- a/src/app/models/tv.py
+++ b/src/app/models/tv.py
@@ -46,7 +46,10 @@ class TV(Media):
         is_create = self._state.adding
         super(Media, self).save(*args, **kwargs)
 
-        if not is_create and self.tracker.has_changed("status"):
+        # A show created directly as COMPLETED (rather than transitioned into it)
+        # must still fan out completion to its seasons/episodes.
+        completed_on_create = is_create and self.status == Status.COMPLETED.value
+        if (not is_create and self.tracker.has_changed("status")) or completed_on_create:
             if self.status == Status.COMPLETED.value:
                 self._completed()
 
@@ -450,7 +453,10 @@ class Season(Media):
         is_create = self._state.adding
         super(Media, self).save(*args, **kwargs)
 
-        if not is_create and self.tracker.has_changed("status"):
+        # A season created directly as COMPLETED (rather than transitioned into
+        # it) must still create the remaining episode watch records.
+        completed_on_create = is_create and self.status == Status.COMPLETED.value
+        if (not is_create and self.tracker.has_changed("status")) or completed_on_create:
             if self.status == Status.COMPLETED.value:
                 season_metadata = providers.services.get_media_metadata(
                     MediaTypes.SEASON.value,

--- a/src/app/tests/models/test_anime_completion_migrates.py
+++ b/src/app/tests/models/test_anime_completion_migrates.py
@@ -1,0 +1,166 @@
+from contextlib import ExitStack
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from app.models import Anime, Item, MediaTypes, Sources, Status
+from app.services.anime_migration import AnimeMigrationError
+
+META = {"max_progress": 13, "episodes": []}
+
+
+class AnimeCompletionAutoMigrateTests(TestCase):
+    """Completing a flat MAL anime should migrate it to episode tracking."""
+
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(username="a", password="x")
+        self.item = Item.objects.create(
+            media_id="10087", source=Sources.MAL.value,
+            media_type=MediaTypes.ANIME.value, title="Fate/Zero",
+        )
+
+    def _make(self, status=Status.PLANNING.value):
+        with patch("app.providers.services.get_media_metadata", return_value=META):
+            return Anime.objects.create(item=self.item, user=self.user, status=status)
+
+    def _env(self, stack, *, series_id="275798", migrate_side_effect=None):
+        """Enter the shared patches and return the migrate mock."""
+        stack.enter_context(
+            patch("app.providers.services.get_media_metadata", return_value=META),
+        )
+        stack.enter_context(
+            patch("app.services.metadata_resolution.provider_is_enabled", return_value=True),
+        )
+        stack.enter_context(
+            patch("app.services.metadata_resolution.metadata_default_source",
+                  return_value=Sources.TVDB.value),
+        )
+        stack.enter_context(
+            patch("integrations.anime_mapping.resolve_provider_series_id",
+                  return_value=series_id),
+        )
+        return stack.enter_context(
+            patch("app.services.anime_migration.migrate_flat_anime_to_grouped",
+                  side_effect=migrate_side_effect),
+        )
+
+    def test_completing_flat_mal_anime_triggers_migration(self):
+        anime = self._make()
+        with ExitStack() as stack:
+            migrate = self._env(stack)
+            anime.status = Status.COMPLETED.value
+            anime.save()
+        migrate.assert_called_once()
+        args, _ = migrate.call_args
+        self.assertEqual(args[0], self.user)
+        self.assertEqual(args[1], self.item)
+        self.assertEqual(args[2], Sources.TVDB.value)
+
+    def test_no_migration_without_provider_mapping(self):
+        anime = self._make()
+        with ExitStack() as stack:
+            migrate = self._env(stack, series_id=None)
+            anime.status = Status.COMPLETED.value
+            anime.save()
+        migrate.assert_not_called()
+
+    def test_no_migration_when_not_completed(self):
+        anime = self._make()
+        with ExitStack() as stack:
+            migrate = self._env(stack)
+            anime.status = Status.PAUSED.value
+            anime.save()
+        migrate.assert_not_called()
+
+    def test_migration_error_is_non_fatal(self):
+        anime = self._make()
+        with ExitStack() as stack:
+            self._env(stack, migrate_side_effect=AnimeMigrationError("no mapping season"))
+            anime.status = Status.COMPLETED.value
+            anime.save()  # must not raise
+        anime.refresh_from_db()
+        self.assertEqual(anime.status, Status.COMPLETED.value)
+
+    def test_end_to_end_creates_episode_records(self):
+        # Drive the real migration (only the provider/network calls are stubbed)
+        # to prove completion produces actual Episode watch records.
+        from app.models import Episode
+        from app.services.tracking_hydration import HydratedItemResult
+
+        anime = self._make()
+
+        tv_item = Item.objects.create(
+            media_id="275798", source=Sources.TVDB.value,
+            media_type=MediaTypes.TV.value, title="Fate/Zero",
+        )
+        season_meta = {
+            "title": "Fate/Zero Season 1",
+            "image": "s.jpg",
+            "episodes": [{"episode_number": n} for n in range(1, 14)],
+        }
+
+        def meta_side_effect(media_type, *args, **kwargs):
+            # anime_migration and process_status share one get_media_metadata.
+            if media_type == "tv_with_seasons":
+                return {"season/1": season_meta}
+            return META  # flat anime max_progress lookup
+
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch("app.providers.services.get_media_metadata",
+                      side_effect=meta_side_effect),
+            )
+            stack.enter_context(
+                patch("app.services.metadata_resolution.provider_is_enabled", return_value=True),
+            )
+            stack.enter_context(
+                patch("app.services.metadata_resolution.metadata_default_source",
+                      return_value=Sources.TVDB.value),
+            )
+            stack.enter_context(
+                patch("integrations.anime_mapping.resolve_provider_series_id",
+                      return_value="275798"),
+            )
+            stack.enter_context(
+                patch("integrations.anime_mapping.find_entries_for_mal_id",
+                      return_value=[{"tvdb_id": "275798", "tvdb_season": 1, "tvdb_epoffset": 0}]),
+            )
+            stack.enter_context(
+                patch("app.services.anime_migration.ensure_item_metadata",
+                      return_value=HydratedItemResult(item=tv_item, metadata={"title": "Fate/Zero"}, created=False)),
+            )
+            stack.enter_context(
+                patch("app.services.anime_migration.upsert_provider_links"),
+            )
+
+            anime.status = Status.COMPLETED.value
+            anime.save()
+
+        # 13 watched episodes created under the TVDB series...
+        self.assertEqual(
+            Episode.objects.filter(
+                related_season__related_tv__user=self.user,
+                item__media_id="275798", item__source=Sources.TVDB.value,
+            ).count(),
+            13,
+        )
+        # ...and the flat MAL entry is now marked migrated.
+        anime.refresh_from_db()
+        self.assertEqual(anime.migrated_to_item_id, tv_item.id)
+
+    def test_already_migrated_not_remigrated(self):
+        other = Item.objects.create(
+            media_id="275798", source=Sources.TVDB.value,
+            media_type=MediaTypes.TV.value, title="Fate/Zero",
+        )
+        anime = self._make()
+        anime.migrated_to_item = other
+        with patch("app.providers.services.get_media_metadata", return_value=META):
+            anime.save()
+
+        with ExitStack() as stack:
+            migrate = self._env(stack)
+            anime.status = Status.COMPLETED.value
+            anime.save()
+        migrate.assert_not_called()

--- a/src/app/tests/models/test_tv_completed_on_create.py
+++ b/src/app/tests/models/test_tv_completed_on_create.py
@@ -1,0 +1,99 @@
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from app.models import Item, MediaTypes, Season, Sources, Status, TV
+
+# Patch the provider lookup used by app.models.tv (imported there as `providers`).
+METADATA_PATH = "app.providers.services.get_media_metadata"
+
+
+class SeasonCompletedOnCreateTests(TestCase):
+    """A season created directly as COMPLETED must still create its episodes."""
+
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(username="u", password="x")
+        self.tv_item = Item.objects.create(
+            media_id="123", source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value, title="Show",
+        )
+        self.tv = TV.objects.create(
+            item=self.tv_item, user=self.user, status=Status.PLANNING.value,
+        )
+        self.season_item = Item.objects.create(
+            media_id="123", source=Sources.TMDB.value,
+            media_type=MediaTypes.SEASON.value, title="Show", season_number=1,
+        )
+
+    @patch(METADATA_PATH)
+    def test_season_created_completed_creates_episodes(self, mock_meta):
+        mock_meta.return_value = {
+            "episodes": [{"episode_number": 1}, {"episode_number": 2}, {"episode_number": 3}],
+            "image": "s.jpg",
+            "max_progress": 3,
+        }
+        season = Season.objects.create(
+            item=self.season_item, user=self.user, related_tv=self.tv,
+            status=Status.COMPLETED.value,
+        )
+        self.assertEqual(season.episodes.count(), 3)
+
+    @patch(METADATA_PATH)
+    def test_season_created_planning_creates_no_episodes(self, mock_meta):
+        # Guard against regressions: non-completed create must not fan out.
+        mock_meta.return_value = {"episodes": [{"episode_number": 1}], "max_progress": 1}
+        season = Season.objects.create(
+            item=self.season_item, user=self.user, related_tv=self.tv,
+            status=Status.PLANNING.value,
+        )
+        self.assertEqual(season.episodes.count(), 0)
+
+    @patch(METADATA_PATH)
+    def test_season_transition_to_completed_still_creates_episodes(self, mock_meta):
+        # The pre-existing transition path must keep working alongside the new
+        # create-as-completed handling.
+        mock_meta.return_value = {
+            "episodes": [{"episode_number": 1}, {"episode_number": 2}],
+            "max_progress": 2,
+        }
+        season = Season.objects.create(
+            item=self.season_item, user=self.user, related_tv=self.tv,
+            status=Status.PLANNING.value,
+        )
+        self.assertEqual(season.episodes.count(), 0)
+        season.status = Status.COMPLETED.value
+        season.save()
+        self.assertEqual(season.episodes.count(), 2)
+
+
+class TVCompletedOnCreateTests(TestCase):
+    """A show created directly as COMPLETED must fan out to seasons/episodes."""
+
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(username="u2", password="x")
+        self.tv_item = Item.objects.create(
+            media_id="777", source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value, title="Show",
+        )
+
+    @patch(METADATA_PATH)
+    def test_tv_created_completed_creates_seasons_and_episodes(self, mock_meta):
+        # One dict serves both the tv metadata and the per-season lookups.
+        mock_meta.return_value = {
+            "max_progress": 6,
+            "related": {"seasons": [
+                {"season_number": 1, "image": "i1.jpg"},
+                {"season_number": 2, "image": "i2.jpg"},
+            ]},
+            "season/1": {"season_number": 1, "image": "i1.jpg",
+                         "episodes": [{"episode_number": 1}, {"episode_number": 2}, {"episode_number": 3}]},
+            "season/2": {"season_number": 2, "image": "i2.jpg",
+                         "episodes": [{"episode_number": 1}, {"episode_number": 2}, {"episode_number": 3}]},
+        }
+        tv = TV.objects.create(
+            item=self.tv_item, user=self.user, status=Status.COMPLETED.value,
+        )
+        self.assertEqual(tv.seasons.filter(status=Status.COMPLETED.value).count(), 2)
+        for season in tv.seasons.all():
+            self.assertTrue(season.episodes.exists())


### PR DESCRIPTION
## Problem

Two related bugs where tracking a title directly as **Completed** in a single
action left it with missing episode/watch records:

### 1. Show or season added directly as Completed creates zero episodes

`TV.save()` and `Season.save()` only fanned out completion (creating the
remaining `Episode` watch records, completing child seasons) when the status
*changed* to Completed on an existing row — guarded by `not is_create`.
Tracking a brand-new show or season straight to Completed therefore left it
with zero episode records.

### 2. Flat MAL anime episodes never marked watched

A flat MAL anime (the single-record `Anime` model) has no per-episode watch
records. Its detail-page episode list is a read-only preview mapped to a
provider (TVDB/TMDB), and each row is marked watched only when a tracked
`Episode` exists for the mapped provider episode. Completing a MAL anime set
its progress counter but left every episode showing unwatched.

## Fix

### Commit 1 — `fix(tv): create episodes when a show/season is added directly as Completed`

Add a `completed_on_create` case so a row created directly as Completed runs
the same completion fan-out as a status transition. Other status branches
(dropped/in-progress) remain update-only. Imports are unaffected: they build
rows via `bulk_create_with_history`, which bypasses `save()`.

### Commit 2 — `feat(anime): mark episodes watched when a flat MAL anime is completed`

When a flat MAL anime becomes COMPLETED, auto-migrate it into grouped
TV-style tracking via the existing `migrate_flat_anime_to_grouped` service.
That creates real `Episode` records for every watched episode under the
mapped provider series, so episodes now show as watched (and gain per-episode
history and ratings). Also covers the create-directly-as-Completed case.

The migration is best-effort and never fatal: if no provider mapping exists,
no grouped provider is enabled, or the provider call fails, the anime simply
stays flat. Provider is chosen from the user's default anime source, then
TVDB, then TMDB (matching the episode-preview candidate order).

## Testing

- `test_tv_completed_on_create.py` — create-as-completed for both Season and
  TV, the transition path, and that a non-completed create does not fan out.
- `test_anime_completion_migrates.py` — completion trigger, guards (no mapping
  / not completed / already migrated), non-fatal error handling, and an
  end-to-end run that creates the Episode records and marks the flat entry
  migrated.

---

Files changed: `src/app/models/tv.py`, `src/app/models/media.py` (+2 test files)
