### PR TITLE
Fix History cache invalidation gaps for episode scores and reading/flat-anime types

### DIFF
--- a/src/app/history_cache.py
+++ b/src/app/history_cache.py
@@ -100,6 +100,7 @@ from app.history_entry_builders import (  # noqa: F401
 from app.models import (
     CREDITS_BACKFILL_VERSION,
     AlbumTracker,
+    Anime,
     BoardGame,
     Book,
     Comic,
@@ -344,11 +345,23 @@ def _build_reading_entries(
     person_id_filter,
     genre_filters,
     reading_media_types,
+    process_all=False,
 ):
-    """Build history entries for books, comics, and manga."""
+    """Build history entries for books, comics, manga, and flat anime.
+
+    These are single-record media types anchored on their completion/activity
+    day. They join the general timeline (``process_all``), a matching media-type
+    filter, or — for the reading types only — an author/person filter.
+    """
     has_person_filter = bool(person_source_filter and person_id_filter)
     has_reading_media_type_filter = media_type_filter in reading_media_types
-    if not (has_person_filter or has_reading_media_type_filter):
+    has_anime_filter = media_type_filter == MediaTypes.ANIME.value
+    if not (
+        process_all
+        or has_person_filter
+        or has_reading_media_type_filter
+        or has_anime_filter
+    ):
         return []
 
     credited_reading_item_ids = None
@@ -362,14 +375,19 @@ def _build_reading_entries(
             ).values_list("item_id", flat=True),
         )
 
+    # Anime is not an authored reading type, so it is excluded from person/author
+    # filtering but included in the general timeline and its own media-type filter.
     reading_model_map = {
         MediaTypes.BOOK.value: Book,
         MediaTypes.COMIC.value: Comic,
         MediaTypes.MANGA.value: Manga,
+        MediaTypes.ANIME.value: Anime,
     }
     entries = []
     for reading_media_type, model in reading_model_map.items():
         if media_type_filter and media_type_filter != reading_media_type:
+            continue
+        if reading_media_type == MediaTypes.ANIME.value and has_person_filter and not media_type_filter:
             continue
         queryset = model.objects.filter(
             user=user,
@@ -861,6 +879,7 @@ def build_history_days(user, filters=None, date_filters=None, logging_style_over
         "books": 0,
         "comics": 0,
         "manga": 0,
+        "anime": 0,
     }
 
     # Parse date filters
@@ -1207,7 +1226,7 @@ def build_history_days(user, filters=None, date_filters=None, logging_style_over
     for entry in _build_reading_entries(
         user, filters, start_date, end_date, media_type_filter,
         target_media_id, target_source, person_source_filter, person_id_filter,
-        genre_filters, reading_media_types,
+        genre_filters, reading_media_types, process_all=process_all,
     ):
         entries.append(entry)
         mt = entry["media_type"]
@@ -1217,6 +1236,8 @@ def build_history_days(user, filters=None, date_filters=None, logging_style_over
             entry_counts["comics"] += 1
         elif mt == MediaTypes.MANGA.value:
             entry_counts["manga"] += 1
+        elif mt == MediaTypes.ANIME.value:
+            entry_counts["anime"] += 1
 
     if process_all or has_music_filter or media_type_filter == MediaTypes.MUSIC.value:
         music_entry_list, music_history_records_scanned, music_album_day_groups = (

--- a/src/app/history_cache_day_builder.py
+++ b/src/app/history_cache_day_builder.py
@@ -37,10 +37,14 @@ from app.history_entry_builders import (
 from app.models import (
     Album,
     AlbumTracker,
+    Anime,
     BoardGame,
+    Book,
+    Comic,
     Episode,
     Game,
     Item,
+    Manga,
     MediaTypes,
     Movie,
     Music,
@@ -164,6 +168,54 @@ def build_history_day(user, day_key, logging_style_override=None):
         repeat_attr = getattr(movie, "repeats", None)
         entry["play_count"] = annotated or repeat_attr or 1
         entries.append(entry)
+
+    # Reading (books, comics, manga) and flat anime — single tracking records
+    # anchored on their completion/activity day, mirroring movies. These appear
+    # in both logging styles since they have no per-session/repeat semantics.
+    for media_type_value, model in (
+        (MediaTypes.BOOK.value, Book),
+        (MediaTypes.COMIC.value, Comic),
+        (MediaTypes.MANGA.value, Manga),
+        (MediaTypes.ANIME.value, Anime),
+    ):
+        records = (
+            model.objects.filter(user=user)
+            .filter(
+                models.Q(end_date__gte=day_start, end_date__lt=day_end)
+                | (
+                    models.Q(end_date__isnull=True)
+                    & models.Q(start_date__gte=day_start, start_date__lt=day_end)
+                ),
+            )
+            .select_related("item")
+        )
+        for record in records:
+            item = getattr(record, "item", None)
+            if not item:
+                continue
+            played_at_local = _localize_datetime(record.end_date or record.start_date)
+            if not played_at_local:
+                continue
+            entry = {
+                "media_type": media_type_value,
+                "item": _serialize_item(item),
+                "poster": item.image or settings.IMG_NONE,
+                "title": item.title,
+                "display_title": item.title,
+                "status": record.status,
+                "episode_label": None,
+                "episode_code": None,
+                "played_at_local": played_at_local,
+                "runtime_minutes": 0,
+                "runtime_display": None,
+                "instance_id": record.id,
+                "entry_key": f"{media_type_value}-{record.id}",
+            }
+            _attach_entry_score(entry, record)
+            genres = _resolve_genres(item)
+            if genres:
+                entry["genres"] = genres
+            entries.append(entry)
 
     # Music (HistoricalMusic for the day)
     HistoricalMusic = apps.get_model("app", "HistoricalMusic")

--- a/src/app/history_cache_utils.py
+++ b/src/app/history_cache_utils.py
@@ -26,7 +26,7 @@ def _coerce_timedelta(value, default):
         return default
 
 
-HISTORY_CACHE_VERSION = 19
+HISTORY_CACHE_VERSION = 20
 HISTORY_INDEX_PREFIX = f"history_index_v{HISTORY_CACHE_VERSION}"
 HISTORY_DAY_PREFIX = f"history_day_v{HISTORY_CACHE_VERSION}"
 HISTORY_CACHE_PREFIX = HISTORY_INDEX_PREFIX

--- a/src/app/score_views.py
+++ b/src/app/score_views.py
@@ -147,6 +147,22 @@ def update_episode_score(request, season_id, episode_number):
         request.user,
     )
 
+    # `episodes.update()` runs a raw SQL UPDATE and does not emit post_save, so
+    # the Episode signal that refreshes the history cache never fires. Invalidate
+    # the affected history day(s) here so the rating shows on the History page.
+    day_keys = [
+        history_cache.history_day_key(end_date)
+        for end_date in episodes.values_list("end_date", flat=True)
+    ]
+    day_keys = [day_key for day_key in day_keys if day_key]
+    if day_keys:
+        history_cache.invalidate_history_days(
+            request.user.id,
+            day_keys=day_keys,
+            logging_styles=("sessions", "repeats"),
+            reason="episode_score_change",
+        )
+
     return JsonResponse(
         {
             "success": True,

--- a/src/app/signals.py
+++ b/src/app/signals.py
@@ -610,10 +610,12 @@ def refresh_statistics_cache_on_anime_change(sender, instance, **kwargs):  # noq
     """
     user_id = getattr(instance, "user_id", None)
     day_keys = _collect_reading_statistics_day_keys(instance)
+    history_day_keys = _collect_reading_history_day_keys(instance)
     _handle_media_cache_change(
         user_id,
         MediaTypes.ANIME.value,
         reason="anime_change",
+        history_specs=[(history_day_keys, ("sessions", "repeats"))],
         statistics_day_values=day_keys,
     )
 
@@ -632,6 +634,18 @@ def _collect_reading_statistics_day_keys(instance):
     return day_keys
 
 
+def _collect_reading_history_day_keys(instance):
+    """Return the history day key(s) where a reading/anime card appears.
+
+    The day builder anchors these single-record types on their end_date (falling
+    back to start_date), so only that one day's cached card needs rebuilding.
+    """
+    activity_key = history_cache.history_day_key(
+        getattr(instance, "end_date", None) or getattr(instance, "start_date", None),
+    )
+    return [activity_key] if activity_key else []
+
+
 @receiver([post_save, post_delete], sender=Manga)
 def refresh_statistics_cache_on_manga_change(sender, instance, **kwargs):  # noqa: ARG001
     """Schedule statistics cache refresh when manga activity changes.
@@ -641,10 +655,12 @@ def refresh_statistics_cache_on_manga_change(sender, instance, **kwargs):  # noq
     """
     user_id = getattr(instance, "user_id", None)
     day_keys = _collect_reading_statistics_day_keys(instance)
+    history_day_keys = _collect_reading_history_day_keys(instance)
     _handle_media_cache_change(
         user_id,
         MediaTypes.MANGA.value,
         reason="manga_change",
+        history_specs=[(history_day_keys, ("sessions", "repeats"))],
         statistics_day_values=day_keys,
     )
 
@@ -658,10 +674,12 @@ def refresh_statistics_cache_on_book_change(sender, instance, **kwargs):  # noqa
     """
     user_id = getattr(instance, "user_id", None)
     day_keys = _collect_reading_statistics_day_keys(instance)
+    history_day_keys = _collect_reading_history_day_keys(instance)
     _handle_media_cache_change(
         user_id,
         MediaTypes.BOOK.value,
         reason="book_change",
+        history_specs=[(history_day_keys, ("sessions", "repeats"))],
         statistics_day_values=day_keys,
     )
 
@@ -675,10 +693,12 @@ def refresh_statistics_cache_on_comic_change(sender, instance, **kwargs):  # noq
     """
     user_id = getattr(instance, "user_id", None)
     day_keys = _collect_reading_statistics_day_keys(instance)
+    history_day_keys = _collect_reading_history_day_keys(instance)
     _handle_media_cache_change(
         user_id,
         MediaTypes.COMIC.value,
         reason="comic_change",
+        history_specs=[(history_day_keys, ("sessions", "repeats"))],
         statistics_day_values=day_keys,
     )
 

--- a/src/app/tests/test_history_reading_anime.py
+++ b/src/app/tests/test_history_reading_anime.py
@@ -1,0 +1,114 @@
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.test import TestCase
+from django.utils import timezone
+
+from app import history_cache
+from app.models import Anime, Book, Item, MediaTypes, Sources, Status
+
+
+def _patch_media_metadata(test_case):
+    """Stop reading/anime model saves from making provider calls."""
+    metadata_patch = patch(
+        "app.models.media.providers.services.get_media_metadata",
+        return_value={"max_progress": 1},
+    )
+    fetch_releases_patch = patch("app.models.Item.fetch_releases")
+    metadata_patch.start()
+    fetch_releases_patch.start()
+    test_case.addCleanup(metadata_patch.stop)
+    test_case.addCleanup(fetch_releases_patch.stop)
+
+
+class ReadingAnimeHistoryDayTests(TestCase):
+    """Books/comics/manga and flat anime should render on the History day view."""
+
+    def setUp(self):
+        cache.clear()
+        _patch_media_metadata(self)
+        self.user = get_user_model().objects.create_user(
+            username="reader", password="12345",
+        )
+        self.now = timezone.localtime().replace(hour=12, minute=0, second=0, microsecond=0)
+        self.day_key = history_cache.history_day_key(self.now)
+        self.addCleanup(cache.clear)
+
+    def _make(self, model, media_type, media_id, title, score):
+        item = Item.objects.create(
+            media_id=media_id,
+            source=Sources.MANUAL.value,
+            media_type=media_type,
+            title=title,
+            image="http://example.com/x.jpg",
+        )
+        return model.objects.create(
+            item=item,
+            user=self.user,
+            status=Status.COMPLETED.value,
+            progress=1,
+            end_date=self.now,
+            score=score,
+        )
+
+    def test_book_and_anime_render_with_score(self):
+        self._make(Book, MediaTypes.BOOK.value, "book-1", "A Book", 9)
+        self._make(Anime, MediaTypes.ANIME.value, "anime-1", "An Anime", 7)
+
+        day = history_cache.build_history_day(self.user, self.day_key)
+        self.assertIsNotNone(day)
+
+        by_type = {e["media_type"]: e for e in day["entries"]}
+        self.assertIn(MediaTypes.BOOK.value, by_type)
+        self.assertIn(MediaTypes.ANIME.value, by_type)
+        self.assertEqual(by_type[MediaTypes.BOOK.value]["score"], 9)
+        self.assertEqual(by_type[MediaTypes.ANIME.value]["score"], 7)
+        self.assertEqual(by_type[MediaTypes.ANIME.value]["status"], Status.COMPLETED.value)
+
+    def test_reading_and_anime_in_uncached_general_timeline(self):
+        # The non-cached builder (used for date-range/filtered views) must also
+        # surface reading/anime in the general timeline, not only when filtered.
+        self._make(Book, MediaTypes.BOOK.value, "book-3", "Timeline Book", 6)
+        self._make(Anime, MediaTypes.ANIME.value, "anime-3", "Timeline Anime", 5)
+
+        history_days = history_cache.build_history_days(self.user)
+        seen_types = {
+            entry["media_type"]
+            for day in history_days
+            for entry in day["entries"]
+        }
+        self.assertIn(MediaTypes.BOOK.value, seen_types)
+        self.assertIn(MediaTypes.ANIME.value, seen_types)
+
+    def test_history_page_renders_reading_and_anime(self):
+        self._make(Book, MediaTypes.BOOK.value, "book-4", "Rendered Book", 9)
+        self._make(Anime, MediaTypes.ANIME.value, "anime-4", "Rendered Anime", 7)
+
+        self.client.force_login(self.user)
+        from django.urls import reverse
+
+        # Use a date range to force the synchronous (non-cached) builder so the
+        # day cards are server-rendered inline rather than deferred to an async
+        # month-cache refresh.
+        day = self.now.date().isoformat()
+        response = self.client.get(
+            reverse("history"), {"start-date": day, "end-date": day},
+        )
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertIn("Rendered Book", content)
+        self.assertIn("Rendered Anime", content)
+
+    def test_score_change_invalidates_history_day(self):
+        book = self._make(Book, MediaTypes.BOOK.value, "book-2", "Rated Book", None)
+
+        with patch("app.signals.history_cache.invalidate_history_days") as mock_invalidate:
+            book.score = 8
+            book.save()
+
+        mock_invalidate.assert_called()
+        called_day_keys = set()
+        for call in mock_invalidate.call_args_list:
+            called_day_keys.update(call.kwargs.get("day_keys") or [])
+        self.assertIn(self.day_key, called_day_keys)

--- a/src/app/tests/views/test_episode_score_invalidation.py
+++ b/src/app/tests/views/test_episode_score_invalidation.py
@@ -1,0 +1,82 @@
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from app import history_cache
+from app.models import Episode, Item, MediaTypes, Season, Sources, TV
+
+
+class UpdateEpisodeScoreInvalidationTests(TestCase):
+    """update_episode_score must invalidate the affected history day cache."""
+
+    def setUp(self):
+        # Episode.save() reaches out to providers for season metadata; stub it.
+        metadata_patch = patch(
+            "app.providers.services.get_media_metadata",
+            return_value={"season/1": {"episodes": [{}, {}]}},
+        )
+        fetch_releases_patch = patch("app.models.Item.fetch_releases")
+        metadata_patch.start()
+        fetch_releases_patch.start()
+        self.addCleanup(metadata_patch.stop)
+        self.addCleanup(fetch_releases_patch.stop)
+
+        self.credentials = {"username": "test", "password": "12345"}
+        self.user = get_user_model().objects.create_user(**self.credentials)
+        self.client.login(**self.credentials)
+
+        tv_item = Item.objects.create(
+            media_id="show-1",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Show",
+        )
+        tv = TV.objects.create(item=tv_item, user=self.user)
+        season_item = Item.objects.create(
+            media_id="show-1",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.SEASON.value,
+            title="Show Season 1",
+            season_number=1,
+        )
+        self.season = Season.objects.create(
+            item=season_item,
+            user=self.user,
+            related_tv=tv,
+        )
+        episode_item = Item.objects.create(
+            media_id="show-1",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.EPISODE.value,
+            title="Episode Two",
+            season_number=1,
+            episode_number=2,
+        )
+        self.end_date = datetime(2026, 7, 3, 12, 0, tzinfo=UTC)
+        self.episode = Episode.objects.create(
+            item=episode_item,
+            related_season=self.season,
+            end_date=self.end_date,
+        )
+
+    def test_rating_episode_invalidates_history_day(self):
+        with patch.object(history_cache, "invalidate_history_days") as mock_invalidate:
+            response = self.client.post(
+                reverse(
+                    "update_episode_score",
+                    kwargs={"season_id": self.season.id, "episode_number": 2},
+                ),
+                {"score": "8"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.episode.refresh_from_db()
+        self.assertEqual(self.episode.score, 8)
+
+        mock_invalidate.assert_called_once()
+        _, kwargs = mock_invalidate.call_args
+        expected_day = history_cache.history_day_key(self.end_date)
+        self.assertEqual(kwargs["day_keys"], [expected_day])


### PR DESCRIPTION
## Problem

Two related gaps in the History timeline cache:

### 1. History cache not invalidated when an episode score changes

`update_episode_score` used a bulk `episodes.update(score=...)` (raw SQL
UPDATE) which does not emit `post_save`. The
`refresh_history_cache_on_episode_change` signal therefore never fired, and
unlike the other score views (movie via `save()`, album/artist via explicit
calls) this endpoint had no invalidation of its own. As a result an episode
rated from the History/detail chip kept its stale, star-less cached History
card until the day was rebuilt for some other reason.

### 2. Books, comics, manga, and flat anime missing from the History timeline

The History day view previously rendered only episodes, movies, music,
podcasts, games, and board games. Reading types (book/comic/manga) surfaced
only when the media-type filter was set to them, and flat MAL-style anime
(the single-record `Anime` model) never appeared at all — even though all of
these are single `Media` records with start/end dates and scores, exactly
like the Games already shown.

## Fix

### Commit 1 — `fix(history): invalidate history cache when an episode score changes`

Collect the affected episodes' `end_date` day keys after the bulk update and
call `history_cache.invalidate_history_days`, mirroring
`update_album_score`. The loop over each record's `end_date` also covers
rewatches spread across multiple days.

### Commit 2 — `feat(history): show books, comics, manga, and flat anime on the History timeline`

- `history_cache_day_builder`: build entries for Book/Comic/Manga/Anime in
  the cached single-day builder, anchored on `end_date` (falling back to
  `start_date`), mirroring the movie section. They appear in both logging
  styles.
- `history_cache._build_reading_entries`: include these types in the
  non-cached general timeline (`process_all`), not only under a matching
  filter, and add flat anime. Anime is excluded from the author/person-credit
  path since it is not an authored reading type.
- `signals`: add `history_specs` to the anime/book/comic/manga change
  receivers so a rating/status/date change invalidates the affected History
  day (previously they only refreshed the statistics cache) — the same gap
  as the episode-score bug.
- Bump `HISTORY_CACHE_VERSION` 19 -> 20 so existing cached months rebuild
  with the new entry types.

Note: TVDB anime tracked with real seasons/episodes already appeared as
episode cards; this covers the flat `Anime` model used by MAL. `ComicIssue`
is left as statistics-only since issues are not rendered as history cards.

## Testing

- `test_episode_score_invalidation.py` — asserts the rating is stored and
  the correct history day is invalidated.
- `test_history_reading_anime.py` — covers the cached builder, the
  non-cached general timeline, the end-to-end page render, and
  score-change invalidation.

---

Files changed: `src/app/score_views.py`, `src/app/history_cache.py`,
`src/app/history_cache_day_builder.py`, `src/app/history_cache_utils.py`,
`src/app/signals.py` (+2 test files)
