### PR TITLE
feat(calendar): create episode events for TVDB-sourced TV shows

### DIFF
--- a/src/events/calendar/selectors.py
+++ b/src/events/calendar/selectors.py
@@ -46,6 +46,12 @@ def filter_items_to_fetch(items):
     )
     tv_items_to_include = get_tv_items_to_include(tv_items)
 
+    tvdb_tv_items = items.filter(
+        media_type=MediaTypes.TV.value,
+        source=Sources.TVDB.value,
+    )
+    tvdb_tv_items_to_include = get_tvdb_tv_items_to_include(tvdb_tv_items)
+
     movie_items = items.filter(
         media_type=MediaTypes.MOVIE.value,
         source=Sources.TMDB.value,
@@ -67,7 +73,7 @@ def filter_items_to_fetch(items):
         latest_comic_event_datetime=Subquery(latest_comic_event.values("datetime")[:1]),
     )
 
-    tv_q = Q(id__in=tv_items_to_include)
+    tv_q = Q(id__in=tv_items_to_include) | Q(id__in=tvdb_tv_items_to_include)
     movie_q = Q(id__in=movie_items_to_include)
 
     comic_q = Q(media_type=MediaTypes.COMIC.value) & (
@@ -123,6 +129,58 @@ def get_tv_items_to_include(tv_items):
         else:
             logger.info(
                 "TV selection: including %s (%s) because it has no season events yet",
+                item["title"],
+                item["media_id"],
+            )
+
+    return [item["id"] for item in included_tv_rows]
+
+
+def get_tvdb_tv_items_to_include(tv_items):
+    """Return tracked TVDB TV item ids that should be refreshed.
+
+    TVDB has no change feed equivalent to TMDB's, so refresh shows that have
+    no season events yet, plus shows that still have future or unknown-date
+    episodes so air dates stay current while a season is ongoing.
+    """
+    if not tv_items.exists():
+        return []
+
+    now = timezone.now()
+    season_events = Event.objects.filter(
+        item__media_id=OuterRef("media_id"),
+        item__source=OuterRef("source"),
+        item__media_type=MediaTypes.SEASON.value,
+    )
+    # Unknown air dates are stored as datetime.min (year 1); future events
+    # include the year-9999 sentinel. Both mean dates may still change.
+    refreshable_season_events = season_events.filter(
+        Q(datetime__gte=now) | Q(datetime__year=1),
+    )
+
+    included_tv_rows = list(
+        tv_items.annotate(
+            has_season_events=Exists(season_events),
+            has_refreshable_events=Exists(refreshable_season_events),
+        )
+        .filter(
+            Q(has_season_events=False) | Q(has_refreshable_events=True),
+        )
+        .values("id", "media_id", "title", "has_season_events"),
+    )
+
+    for item in included_tv_rows:
+        if item["has_season_events"]:
+            logger.info(
+                "TVDB TV selection: including %s (%s) because it has "
+                "future or unknown-date episodes",
+                item["title"],
+                item["media_id"],
+            )
+        else:
+            logger.info(
+                "TVDB TV selection: including %s (%s) because it has "
+                "no season events yet",
                 item["title"],
                 item["media_id"],
             )

--- a/src/events/calendar/tv.py
+++ b/src/events/calendar/tv.py
@@ -11,8 +11,8 @@ from django.utils import timezone
 from simple_history.utils import bulk_create_with_history, bulk_update_with_history
 
 from app import cache_utils
-from app.models import TV, Item, MediaTypes, Season, Status
-from app.providers import services, tmdb
+from app.models import TV, Item, MediaTypes, Season, Sources, Status
+from app.providers import services, tmdb, tvdb
 from events.models import Event
 
 from .helpers import date_parser
@@ -70,10 +70,15 @@ def process_tv(tv_item, events_bulk, tv_metadata=None):
         logger.exception("Error processing %s", tv_item)
 
 
+def _tv_provider(source):
+    """Return the metadata provider module for a TV item's source."""
+    return tvdb if source == Sources.TVDB.value else tmdb
+
+
 def get_seasons_to_process(tv_item, tv_metadata=None):
     """Identify which seasons of a TV show need to be processed."""
     if tv_metadata is None:
-        tv_metadata = tmdb.tv(tv_item.media_id)
+        tv_metadata = _tv_provider(tv_item.source).tv(tv_item.media_id)
 
     if not tv_metadata.get("related", {}).get("seasons"):
         logger.warning("No seasons found for TV show: %s", tv_item)
@@ -98,11 +103,22 @@ def get_seasons_to_process(tv_item, tv_metadata=None):
     ).select_related("item")
 
     seasons_with_events = {event.item.season_number for event in existing_season_events}
+    # Seasons whose events can still change: future air dates (including the
+    # year-9999 unknown-date sentinel) or the datetime.min unknown-date
+    # fallback. TMDB refreshes these via next_episode_season, but sources
+    # without that field (TVDB) rely on this to keep ongoing seasons current.
+    now = timezone.now()
+    seasons_with_refreshable_events = {
+        event.item.season_number
+        for event in existing_season_events
+        if event.datetime >= now or event.datetime.year == 1
+    }
     seasons_to_process = [
         season_num
         for season_num in season_numbers
         if season_num not in seasons_with_events
         or (next_episode_season and season_num >= next_episode_season)
+        or season_num in seasons_with_refreshable_events
     ]
 
     if not seasons_to_process:
@@ -120,7 +136,7 @@ def get_seasons_to_process(tv_item, tv_metadata=None):
 
 def process_tv_seasons(tv_item, seasons_to_process, events_bulk):
     """Process specific seasons of a TV show."""
-    process_seasons_data = tmdb.tv_with_seasons(
+    process_seasons_data = _tv_provider(tv_item.source).tv_with_seasons(
         tv_item.media_id,
         seasons_to_process,
     )

--- a/src/events/tests/calendar/test_selectors.py
+++ b/src/events/tests/calendar/test_selectors.py
@@ -147,6 +147,108 @@ class CalendarSelectorTests(CalendarFixturesMixin, TestCase):
 
         self.assertIn(self.tv_item, items)
 
+    def _create_tvdb_tv(self):
+        tvdb_tv_item = Item.objects.create(
+            media_id="418666",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Witch Hat Atelier",
+            image="http://example.com/witchhat.jpg",
+        )
+        TV.objects.create(
+            item=tvdb_tv_item,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+        )
+        tvdb_season_item = Item.objects.create(
+            media_id="418666",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.SEASON.value,
+            title="Witch Hat Atelier",
+            image="http://example.com/witchhat.jpg",
+            season_number=1,
+        )
+        return tvdb_tv_item, tvdb_season_item
+
+    @patch("events.calendar.selectors.tmdb.movie_changes")
+    @patch("events.calendar.selectors.tmdb.tv_changes")
+    def test_get_items_to_process_includes_tvdb_tv_without_season_events(
+        self,
+        mock_tv_changes,
+        mock_movie_changes,
+    ):
+        """Tracked TVDB TV should bootstrap even when no season events exist yet."""
+        mock_tv_changes.return_value = set()
+        mock_movie_changes.return_value = set()
+        tvdb_tv_item, _ = self._create_tvdb_tv()
+
+        items = get_items_to_process(self.user)
+
+        self.assertIn(tvdb_tv_item, items)
+
+    @patch("events.calendar.selectors.tmdb.movie_changes")
+    @patch("events.calendar.selectors.tmdb.tv_changes")
+    def test_get_items_to_process_includes_tvdb_tv_with_future_events(
+        self,
+        mock_tv_changes,
+        mock_movie_changes,
+    ):
+        """TVDB TV with future season events should refresh to keep dates current."""
+        mock_tv_changes.return_value = set()
+        mock_movie_changes.return_value = set()
+        tvdb_tv_item, tvdb_season_item = self._create_tvdb_tv()
+        Event.objects.create(
+            item=tvdb_season_item,
+            content_number=1,
+            datetime=timezone.now() + timezone.timedelta(days=7),
+        )
+
+        items = get_items_to_process(self.user)
+
+        self.assertIn(tvdb_tv_item, items)
+
+    @patch("events.calendar.selectors.tmdb.movie_changes")
+    @patch("events.calendar.selectors.tmdb.tv_changes")
+    def test_get_items_to_process_includes_tvdb_tv_with_unknown_date_events(
+        self,
+        mock_tv_changes,
+        mock_movie_changes,
+    ):
+        """TVDB TV with datetime.min unknown-date events should keep refreshing."""
+        mock_tv_changes.return_value = set()
+        mock_movie_changes.return_value = set()
+        tvdb_tv_item, tvdb_season_item = self._create_tvdb_tv()
+        Event.objects.create(
+            item=tvdb_season_item,
+            content_number=1,
+            datetime=timezone.now().replace(year=1, month=1, day=1),
+        )
+
+        items = get_items_to_process(self.user)
+
+        self.assertIn(tvdb_tv_item, items)
+
+    @patch("events.calendar.selectors.tmdb.movie_changes")
+    @patch("events.calendar.selectors.tmdb.tv_changes")
+    def test_get_items_to_process_excludes_tvdb_tv_with_only_past_events(
+        self,
+        mock_tv_changes,
+        mock_movie_changes,
+    ):
+        """Fully aired TVDB TV should not be refetched every run."""
+        mock_tv_changes.return_value = set()
+        mock_movie_changes.return_value = set()
+        tvdb_tv_item, tvdb_season_item = self._create_tvdb_tv()
+        Event.objects.create(
+            item=tvdb_season_item,
+            content_number=1,
+            datetime=timezone.now() - timezone.timedelta(days=30),
+        )
+
+        items = get_items_to_process(self.user)
+
+        self.assertNotIn(tvdb_tv_item, items)
+
     @patch("events.calendar.selectors.tmdb.tv_changes")
     def test_get_changed_tmdb_tv_ids_returns_empty_on_provider_error(
         self,

--- a/src/events/tests/calendar/test_tv.py
+++ b/src/events/tests/calendar/test_tv.py
@@ -6,7 +6,7 @@ import requests
 from django.core.cache import cache
 from django.test import TestCase
 
-from app.models import TV, Item, Season, Status
+from app.models import TV, Item, MediaTypes, Season, Sources, Status
 from events.calendar.helpers import date_parser
 from events.calendar.tv import (
     get_episode_datetime,
@@ -361,3 +361,116 @@ class CalendarTVTests(CalendarFixturesMixin, TestCase):
         ]
 
         self.assertEqual(get_tvmaze_response("81189"), {})
+
+    def test_get_seasons_to_process_refreshes_seasons_with_future_events(self):
+        """Seasons with future or unknown-date events should be reprocessed.
+
+        Sources without TMDB's next_episode_season field (TVDB) rely on this
+        to keep air dates current while a season is ongoing.
+        """
+        future_date = datetime.datetime.now(tz=ZoneInfo("UTC")) + datetime.timedelta(
+            days=7,
+        )
+        Event.objects.create(
+            item=self.season_item,
+            content_number=1,
+            datetime=future_date,
+        )
+        tv_metadata = {
+            "related": {
+                "seasons": [{"season_number": 1}],
+            },
+        }
+
+        self.assertEqual(
+            get_seasons_to_process(self.tv_item, tv_metadata=tv_metadata),
+            [1],
+        )
+
+    def test_get_seasons_to_process_skips_seasons_with_only_past_events(self):
+        """Fully aired seasons without next_episode_season should stay untouched."""
+        Event.objects.create(
+            item=self.season_item,
+            content_number=1,
+            datetime=date_parser("2008-01-20"),
+        )
+        tv_metadata = {
+            "related": {
+                "seasons": [{"season_number": 1}],
+            },
+        }
+
+        self.assertEqual(
+            get_seasons_to_process(self.tv_item, tv_metadata=tv_metadata),
+            [],
+        )
+
+    @patch("events.calendar.tv.get_tvmaze_episode_map")
+    @patch("events.calendar.tv.tvdb.tv_with_seasons")
+    @patch("events.calendar.tv.tvdb.tv")
+    @patch("events.calendar.tv.tmdb.tv")
+    def test_process_tv_tvdb_source_uses_tvdb_provider(
+        self,
+        mock_tmdb_tv,
+        mock_tvdb_tv,
+        mock_tvdb_tv_with_seasons,
+        mock_get_tvmaze_episode_map,
+    ):
+        """TVDB-sourced shows should fetch metadata from the TVDB provider."""
+        tvdb_tv_item = Item.objects.create(
+            media_id="418666",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.TV.value,
+            title="Witch Hat Atelier",
+            image="http://example.com/witchhat.jpg",
+        )
+        TV.objects.create(
+            item=tvdb_tv_item,
+            user=self.user,
+            status=Status.IN_PROGRESS.value,
+        )
+
+        mock_tvdb_tv.return_value = {
+            "related": {
+                "seasons": [{"season_number": 1, "episodes": [1, 2]}],
+            },
+        }
+        mock_tvdb_tv_with_seasons.return_value = {
+            "season/1": {
+                "image": "http://example.com/witchhat-s1.jpg",
+                "season_number": 1,
+                "episodes": [
+                    {"episode_number": 1, "air_date": "2026-04-06"},
+                    {"episode_number": 2, "air_date": "2026-04-13"},
+                ],
+                "tvdb_id": "418666",
+            },
+        }
+        mock_get_tvmaze_episode_map.return_value = {
+            "1_1": "2026-04-06T14:00:00+00:00",
+        }
+
+        events_bulk = []
+        process_tv(tvdb_tv_item, events_bulk)
+
+        mock_tmdb_tv.assert_not_called()
+        mock_tvdb_tv.assert_called_once_with("418666")
+        mock_tvdb_tv_with_seasons.assert_called_once_with("418666", [1])
+        mock_get_tvmaze_episode_map.assert_called_once_with("418666")
+
+        self.assertEqual(len(events_bulk), 2)
+        season_item = Item.objects.get(
+            media_id="418666",
+            source=Sources.TVDB.value,
+            media_type=MediaTypes.SEASON.value,
+            season_number=1,
+        )
+        self.assertEqual(events_bulk[0].item, season_item)
+        self.assertEqual(
+            events_bulk[0].datetime,
+            datetime.datetime.fromisoformat("2026-04-06T14:00:00+00:00"),
+        )
+        self.assertEqual(
+            events_bulk[1].datetime,
+            date_parser("2026-04-13"),
+        )


### PR DESCRIPTION
## Summary

- TVDB-sourced shows never produced calendar events: `filter_items_to_fetch` only selected TV items with `source=tmdb` (and the `other_q` catch-all excludes TV entirely), and `process_tv` always fetched metadata from `tmdb.tv()` even for TVDB ids.
- Routes the TV metadata fetch through the provider matching the item's source; the `tvdb` provider already exposes an interface-compatible `tv()` and `tv_with_seasons()`, and its season payloads carry the `tvdb_id` the TVMaze airstamp lookup needs.
- Adds `get_tvdb_tv_items_to_include` to select TVDB shows for refresh: TVDB has no change feed like TMDB's, so it includes shows with no season events yet plus shows that still have future or unknown-date (`datetime.min`) events, and skips fully aired ones.
- `get_seasons_to_process` now also reprocesses seasons that still have future or unknown-date events. TMDB covers those via `next_episode_season`, which TVDB metadata lacks; without this, an ongoing TVDB season would never refresh after its first fetch.

## Test plan

- [x] `python manage.py check` passes
- [x] Unit tests cover TVDB selection (no events, future events, unknown-date events, fully-aired exclusion) and provider routing
- [x] Verified against the live TVDB API: Witch Hat Atelier (`tvdb/418666`) now yields 13 S1 events with precise TVMaze airstamps where it previously produced none