### PR TITLE
fix podcast library view visual bugs + add podcast episode progress % to home screen

### DIFF
--- a/src/app/media_list_views.py
+++ b/src/app/media_list_views.py
@@ -1988,6 +1988,8 @@ def media_list(request, media_type):
             "media_type_plural": app_tags.media_type_readable_plural(media_type).lower(),
             "current_layout": layout,
             "layout_class": ".media-grid" if layout == "grid" else ".media-table",
+            "media_list_url": reverse("medialist", args=[media_type]),
+            "filter_hx_target": (".media-grid" if layout == "grid" else ".media-table") if media_page else "#empty_list",
             "current_sort": sort_filter,
             "current_direction": direction,
             "current_status": status_filter,

--- a/src/app/models/manager.py
+++ b/src/app/models/manager.py
@@ -1098,6 +1098,7 @@ class MediaManager(models.Manager):
             select_related_fields = ["item"]
             if media_type == MediaTypes.PODCAST.value:
                 select_related_fields.append("show")
+                select_related_fields.append("episode")
             elif media_type == MediaTypes.MUSIC.value:
                 select_related_fields.append("album")
 

--- a/src/app/models/podcast.py
+++ b/src/app/models/podcast.py
@@ -173,6 +173,31 @@ class Podcast(Media):
         minutes = (self.progress or 0) // 60
         return f"{minutes}m"
 
+    @property
+    def progress_percentage(self):
+        """Return percent listened through the current episode (0-100), or None.
+
+        Podcasts are tracked per episode, so this is the playback position within
+        a single episode relative to its runtime. Prefers the episode's precise 
+        duration and falls back to the item runtime; returns None when the 
+        position or a runtime is unavailable.
+        """
+        if not self.played_up_to_seconds:
+            return None
+
+        total_seconds = None
+        episode = self.episode
+        if episode and episode.duration:
+            total_seconds = episode.duration
+        elif self.item and self.item.runtime_minutes:
+            total_seconds = self.item.runtime_minutes * 60
+
+        if not total_seconds:
+            return None
+
+        percentage = round(self.played_up_to_seconds / total_seconds * 100)
+        return max(0, min(percentage, 100))
+
 
 class PodcastShowTracker(models.Model):
     """Model for tracking podcast shows in user's library.

--- a/src/integrations/imports/pocketcasts.py
+++ b/src/integrations/imports/pocketcasts.py
@@ -1375,7 +1375,7 @@ class PocketCastsImporter:
             "published":     metadata_ep.get("published", ""),
             "url":           metadata_ep.get("url", ""),
             "fileType":      metadata_ep.get("file_type", ""),
-            "duration":      metadata_ep.get("duration") or play_state.get("duration", 0),  # noqa: E501
+            "duration":      play_state.get("duration") or metadata_ep.get("duration", 0),  # noqa: E501
             "episodeType":   metadata_ep.get("type", "full"),
             "episodeSeason": metadata_ep.get("season"),
             "episodeNumber": metadata_ep.get("number"),

--- a/src/templates/app/components/media_card.html
+++ b/src/templates/app/components/media_card.html
@@ -208,7 +208,16 @@
           {% if media and user.progress_bar %}
             {% with bar_status=media.aggregated_status|default:media.status %}
               {% if bar_status == Status.IN_PROGRESS.value or bar_status == Status.PAUSED.value %}
-                {% if resolved_media_type != MediaTypes.MOVIE.value and media.max_progress and media.progress %}
+                {% if resolved_media_type == MediaTypes.PODCAST.value %}
+                  {% with progress_percent=media|safe_attr:"progress_percentage" %}
+                    {% if progress_percent is not None %}
+                      <div class="media-card-progress-bar absolute bottom-0 left-0 right-0 h-1 bg-gray-900/60 z-20">
+                        <div class="h-full {% if bar_status == Status.PAUSED.value %}bg-indigo-500/40{% else %}bg-indigo-500{% endif %} transition-[width] duration-300 ease-out"
+                             style="width: {{ progress_percent }}%"></div>
+                      </div>
+                    {% endif %}
+                  {% endwith %}
+                {% elif resolved_media_type != MediaTypes.MOVIE.value and media.max_progress and media.progress %}
                   {% widthratio media.progress media.max_progress 100 as progress_percent %}
                   {# Any overshoot (progress > max) renders as a full bar — the card's overflow-hidden clips it. #}
                   <div class="media-card-progress-bar absolute bottom-0 left-0 right-0 h-1 bg-gray-900/60 z-20">
@@ -486,7 +495,16 @@
               {% elif show_episode_identity|default:False and item.season_number != None and item.episode_number != None %}
                 <p class="media-card-year text-xs text-gray-400 mt-1">S{{ item.season_number|stringformat:"02d" }} E{{ item.episode_number|stringformat:"02d" }}</p>
               {% elif use_podcast_show|default:False and podcast_show %}
-                <p class="media-card-year text-xs text-gray-400 mt-1 line-clamp-1">{{ podcast_show.title }}</p>
+                <p class="media-card-year text-xs text-gray-400 mt-1 line-clamp-1">
+                  {{ podcast_show.title }}
+                  {% with podcast_status=media.aggregated_status|default:media.status podcast_percent=media|safe_attr:"progress_percentage" %}
+                    {% if podcast_percent is not None %}
+                      {% if podcast_status == Status.IN_PROGRESS.value or podcast_status == Status.PAUSED.value %}
+                        <span class="ml-1 text-gray-400">• {{ podcast_percent }}%</span>
+                      {% endif %}
+                    {% endif %}
+                  {% endwith %}
+                </p>
               {% elif subtitle_override or subtitle_match_percent == 0 or subtitle_match_percent %}
                 <p class="media-card-year text-xs text-gray-400 mt-1">
                   {% if subtitle_override %}

--- a/src/users/home_screen.py
+++ b/src/users/home_screen.py
@@ -2162,9 +2162,16 @@ def _build_row_section(
     prefill_display_release_years(section_entries)
     loaded_count = min(len(entries), batch_start + len(section_entries))
     title_main, title_detail = home_row_header_title_parts(row, user)
+
+    def _entry_missing_cover(entry):
+        if getattr(entry, "use_podcast_show", False) and getattr(entry, "podcast_show", None):
+            image = entry.podcast_show.image
+        else:
+            image = entry.item.image
+        return not image or image == settings.IMG_NONE
+
     poll_for_covers = media_type in SQUARE_HOME_MEDIA_TYPES and any(
-        not e.item.image or e.item.image == settings.IMG_NONE
-        for e in section_entries
+        _entry_missing_cover(e) for e in section_entries
     )
     return {
         "row_id": row.id,

--- a/src/users/home_screen.py
+++ b/src/users/home_screen.py
@@ -1587,7 +1587,7 @@ def _media_lookup_for_items(
             item_id__in=[item.id for item in type_items],
         ).select_related("item")
         if actual_media_type == MediaTypes.PODCAST.value:
-            queryset = queryset.select_related("show")
+            queryset = queryset.select_related("show", "episode")
         if actual_media_type == MediaTypes.MUSIC.value:
             queryset = queryset.select_related("album")
         queryset = BasicMedia.objects._apply_prefetch_related(queryset, actual_media_type)


### PR DESCRIPTION
## Summary

**Biggest issues:** 

- Fixed the podcast library sort dropdown injecting your tracked shows' album art near the clicked option. The view was missing two routing keys, so every toolbar button had empty hx targets.

- "Refreshing artwork" was stuck forever on the home screen, sometimes with the podcast row flashing. Podcast cards show the show's artwork, not the episode's, and episodes are saved without their own image. The poller checked the episode's image, which is saved blank on purpose, so the row always looked like it was missing covers and never stopped. Now it checks the show's art instead.

Also:
- Added podcast listen-progress percentage to home screen cards. In-progress podcasts now show the show name plus how far you are through the current episode, like "Search Engine • 29%".

- Fixed the podcast progress bar. It was inconsistent and wrong before because it divided your position by the show's episode count instead of the episode length. Now it matches the subtitle percentage and shows up every time.

- Fixed podcast percentages reading too high on some shows. Podcasts that stitch in ads at playback are longer than their listed length, so dividing your position by the shorter listed length overstated your progress (and would show 100% before you actually finished). We now use the true episode length Pocket Casts reports, and existing episodes correct themselves on the next sync.

## Errant behavior

_**Empty hx targets in podcast library view**_

https://github.com/user-attachments/assets/0f2be21d-1401-4554-87f6-adb78b2ca5d9

_**Flashing podcast artwork on home screen (also pressed refresh and hard refresh in the clip)**_

https://github.com/user-attachments/assets/859b2ae2-3157-4a05-bc6d-4003746fc061


_**Home screen progress percentage**_
_(now uses per-episode progress)_
Before             |  After
:-------------------------:|:-------------------------:
 ![](https://github.com/user-attachments/assets/275e47d6-a805-47f3-8151-6f31bcb1dc0f) | ![](https://github.com/user-attachments/assets/936f6ad0-ae2d-4a9e-9118-14768913f27d) 

Before             |  After
:-------------------------:|:-------------------------:
 ![](https://github.com/user-attachments/assets/a3ebb426-c268-412c-89ca-70566bbd8e2a) | ![](https://github.com/user-attachments/assets/77e6043f-2c80-45df-8123-9b7af81dd06c) 


 

## Notes
**Code written with the help of Claude Opus.**
