### PR TITLE
Add auto-complete search for tracked items

### DIFF
--- a/src/app/search_views.py
+++ b/src/app/search_views.py
@@ -23,9 +23,13 @@ from app.models import (
 )
 from app.providers import services
 from app.services import metadata_resolution
+from app.templatetags.app_tags import media_url, music_album_url, music_artist_url
 from users.models import MediaStatusChoices
 
 logger = logging.getLogger(__name__)
+
+# Minimum characters before the search bar fires autocomplete suggestions.
+MIN_SUGGESTION_QUERY_LENGTH = 2
 
 
 def _mark_grouped_anime_route(media_items):
@@ -38,6 +42,71 @@ def _mark_grouped_anime_route(media_items):
     return media_items
 
 
+def _norm(text):
+    return str(text or "").strip().casefold()
+
+
+def _title_fields(item_obj):
+    if isinstance(item_obj, dict):
+        return (
+            item_obj.get("title"),
+            item_obj.get("original_title"),
+            item_obj.get("localized_title"),
+        )
+    return (
+        getattr(item_obj, "title", None),
+        getattr(item_obj, "original_title", None),
+        getattr(item_obj, "localized_title", None),
+    )
+
+
+def _display_title_for_user(item_obj, user):
+    if hasattr(item_obj, "get_display_title"):
+        return item_obj.get_display_title(user=user)
+
+    title, original_title, localized_title = _title_fields(item_obj)
+    title = str(title or "").strip()
+    original_title = str(original_title or "").strip() or None
+    localized_title = str(localized_title or "").strip() or None
+
+    if not localized_title and title:
+        localized_title = title
+
+    preference = getattr(user, "title_display_preference", "localized")
+    if preference == "original":
+        return original_title or localized_title or title
+    return localized_title or original_title or title
+
+
+def _matched_title(item_obj, search_query, user):
+    normalized_query = _norm(search_query)
+    if not normalized_query:
+        return None
+
+    display_title = _display_title_for_user(item_obj, user)
+    display_norm = _norm(display_title)
+
+    title, original_title, localized_title = _title_fields(item_obj)
+    candidates = []
+    for candidate in (title, localized_title, original_title):
+        text = str(candidate or "").strip()
+        if text and text not in candidates:
+            candidates.append(text)
+
+    # Prefer exact, then prefix, then contains.
+    for predicate in (
+        lambda value: _norm(value) == normalized_query,
+        lambda value: _norm(value).startswith(normalized_query),
+        lambda value: normalized_query in _norm(value),
+    ):
+        for candidate in candidates:
+            if _norm(candidate) == display_norm:
+                continue
+            if predicate(candidate):
+                return candidate
+    return None
+
+
 @require_GET
 def media_search(request):
     """Return the media search page."""
@@ -48,67 +117,6 @@ def media_search(request):
     query = request.GET["q"]
     page = int(request.GET.get("page", 1))
     layout = request.GET.get("layout", "grid")
-
-    def _norm(text):
-        return str(text or "").strip().casefold()
-
-    def _title_fields(item_obj):
-        if isinstance(item_obj, dict):
-            return (
-                item_obj.get("title"),
-                item_obj.get("original_title"),
-                item_obj.get("localized_title"),
-            )
-        return (
-            getattr(item_obj, "title", None),
-            getattr(item_obj, "original_title", None),
-            getattr(item_obj, "localized_title", None),
-        )
-
-    def _display_title_for_user(item_obj):
-        if hasattr(item_obj, "get_display_title"):
-            return item_obj.get_display_title(user=request.user)
-
-        title, original_title, localized_title = _title_fields(item_obj)
-        title = str(title or "").strip()
-        original_title = str(original_title or "").strip() or None
-        localized_title = str(localized_title or "").strip() or None
-
-        if not localized_title and title:
-            localized_title = title
-
-        preference = getattr(request.user, "title_display_preference", "localized")
-        if preference == "original":
-            return original_title or localized_title or title
-        return localized_title or original_title or title
-
-    def _matched_title(item_obj, search_query):
-        normalized_query = _norm(search_query)
-        if not normalized_query:
-            return None
-
-        display_title = _display_title_for_user(item_obj)
-        display_norm = _norm(display_title)
-
-        title, original_title, localized_title = _title_fields(item_obj)
-        candidates = []
-        for candidate in (title, localized_title, original_title):
-            text = str(candidate or "").strip()
-            if text and text not in candidates:
-                candidates.append(text)
-
-        # Prefer exact, then prefix, then contains.
-        for predicate in (
-            lambda value: _norm(value) == normalized_query,
-            lambda value: _norm(value).startswith(normalized_query),
-            lambda value: normalized_query in _norm(value),
-        ):
-            for candidate in candidates:
-                if _norm(candidate) == display_norm:
-                    continue
-                if predicate(candidate):
-                    return candidate
-        return None
 
     local_results = []
     local_results_total = 0
@@ -164,7 +172,7 @@ def media_search(request):
                     {
                         "item": media.item,
                         "media": media,
-                        "matched_title": _matched_title(media.item, query),
+                        "matched_title": _matched_title(media.item, query, request.user),
                     }
                     for media in adapted_media
                 ]
@@ -254,7 +262,7 @@ def media_search(request):
                     {
                         "item": media.item,
                         "media": media,
-                        "matched_title": _matched_title(media.item, query),
+                        "matched_title": _matched_title(media.item, query, request.user),
                     }
                     for media in local_media
                 ]
@@ -303,7 +311,7 @@ def media_search(request):
             section_name="search",
         )
         for result in data["results"]:
-            result["matched_title"] = _matched_title(result.get("item"), query)
+            result["matched_title"] = _matched_title(result.get("item"), query, request.user)
 
     context = {
         "user": request.user,
@@ -319,3 +327,184 @@ def media_search(request):
     }
 
     return render(request, "app/search.html", context)
+
+
+def _safe_url(builder, target):
+    """Return a detail URL for a suggestion, or None if it can't be built."""
+    try:
+        url = builder(target)
+    except Exception:  # pragma: no cover - defensive against reverse failures
+        return None
+    return url or None
+
+
+def get_saved_suggestions(user, media_type, query, limit=8):
+    """Return compact autocomplete suggestions from the user's saved library.
+
+    Saved items only, scoped to ``media_type``. Each suggestion is a dict of
+    ``{title, subtitle, image, url}``. Mirrors the local-results queries used by
+    :func:`media_search` but capped small and side-effect free for typeahead.
+    """
+    suggestions = []
+
+    if media_type == MediaTypes.PODCAST.value:
+        show_trackers = (
+            PodcastShowTracker.objects.filter(user=user)
+            .exclude(show__title__isnull=True)
+            .exclude(show__title__exact="")
+            .filter(show__title__icontains=query)
+            .select_related("show")
+            .order_by("show__title")[:limit]
+        )
+        for tracker in show_trackers:
+            show = tracker.show
+            url = _safe_url(
+                media_url,
+                {
+                    "media_type": MediaTypes.PODCAST.value,
+                    "source": Sources.POCKETCASTS.value,
+                    "media_id": show.podcast_uuid,
+                    "title": show.title,
+                },
+            )
+            if url:
+                suggestions.append({
+                    "title": show.title,
+                    "subtitle": None,
+                    "image": show.image or None,
+                    "url": url,
+                })
+        return suggestions
+
+    if media_type == MediaTypes.MUSIC.value:
+        artist_trackers = (
+            ArtistTracker.objects.filter(user=user)
+            .exclude(artist__name__isnull=True)
+            .exclude(artist__name__exact="")
+            .filter(artist__name__icontains=query)
+            .select_related("artist")
+            .order_by("artist__name")[:limit]
+        )
+        for tracker in artist_trackers:
+            url = _safe_url(music_artist_url, tracker.artist)
+            if url:
+                suggestions.append({
+                    "title": tracker.artist.name,
+                    "subtitle": "Artist",
+                    "image": getattr(tracker.artist, "image", None) or None,
+                    "url": url,
+                })
+
+        album_trackers = (
+            AlbumTracker.objects.filter(user=user)
+            .exclude(album__title__isnull=True)
+            .exclude(album__title__exact="")
+            .filter(
+                Q(album__title__icontains=query)
+                | Q(album__artist__name__icontains=query),
+            )
+            .select_related("album", "album__artist")
+            .order_by("album__title")[:limit]
+        )
+        for tracker in album_trackers:
+            url = _safe_url(music_album_url, tracker.album)
+            if url:
+                album_artist = getattr(tracker.album, "artist", None)
+                artist_name = getattr(album_artist, "name", None)
+                suggestions.append({
+                    "title": tracker.album.title,
+                    "subtitle": artist_name or "Album",
+                    "image": getattr(tracker.album, "image", None) or None,
+                    "url": url,
+                })
+        return suggestions[:limit]
+
+    local_queryset = BasicMedia.objects.get_media_list(
+        user,
+        media_type,
+        MediaStatusChoices.ALL,
+        "title",
+        search=query,
+        direction="asc",
+    )
+    local_media = list(local_queryset)
+
+    anime_mode = getattr(user, "anime_library_mode", MediaTypes.ANIME.value)
+    if media_type == MediaTypes.TV.value and anime_mode == MediaTypes.ANIME.value:
+        local_media = [
+            media
+            for media in local_media
+            if getattr(getattr(media, "item", None), "library_media_type", None)
+            != MediaTypes.ANIME.value
+        ]
+    elif media_type == MediaTypes.ANIME.value and anime_mode in {
+        MediaTypes.ANIME.value,
+        "both",
+    }:
+        grouped = [
+            media
+            for media in BasicMedia.objects.get_media_list(
+                user,
+                MediaTypes.TV.value,
+                MediaStatusChoices.ALL,
+                "title",
+                search=query,
+                direction="asc",
+            )
+            if getattr(getattr(media, "item", None), "library_media_type", None)
+            == MediaTypes.ANIME.value
+        ]
+        _mark_grouped_anime_route(grouped)
+        local_media.extend(grouped)
+        local_media.sort(
+            key=lambda media: getattr(
+                getattr(media, "item", None),
+                "title",
+                "",
+            ).lower(),
+        )
+
+    for media in local_media[:limit]:
+        item = getattr(media, "item", None)
+        if item is None:
+            continue
+        url = _safe_url(media_url, item)
+        if not url:
+            continue
+        suggestions.append({
+            "title": _display_title_for_user(item, user),
+            "subtitle": _matched_title(item, query, user),
+            "image": getattr(item, "image", None) or None,
+            "url": url,
+        })
+    return suggestions
+
+
+@require_GET
+def search_suggestions(request):
+    """Return the autocomplete dropdown fragment for the global search bar."""
+    query = request.GET.get("q", "").strip()
+    media_type = request.GET.get("media_type", "")
+
+    if (
+        not request.user.is_authenticated
+        or len(query) < MIN_SUGGESTION_QUERY_LENGTH
+        or media_type not in {choice.value for choice in MediaTypes}
+    ):
+        return render(request, "app/components/search_suggestions.html")
+
+    try:
+        suggestions = get_saved_suggestions(request.user, media_type, query)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("Suggestion search failed: %s", exception_summary(exc))
+        suggestions = []
+
+    return render(
+        request,
+        "app/components/search_suggestions.html",
+        {
+            "suggestions": suggestions,
+            "query": query,
+            "media_type": media_type,
+        },
+    )

--- a/src/app/tests/test_search_suggestions.py
+++ b/src/app/tests/test_search_suggestions.py
@@ -1,0 +1,86 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from app.models import Item, MediaTypes, Movie, Sources
+from users.models import Status
+
+
+class SearchSuggestionsViewTests(TestCase):
+    """Tests for the saved-library autocomplete suggestions endpoint."""
+
+    def setUp(self):
+        """Create a user with one saved movie and log them in."""
+        self.user = get_user_model().objects.create_user(
+            username="suggest-user",
+            password="12345",  # noqa: S106
+        )
+        self.client.force_login(self.user)
+
+        self.item = Item.objects.create(
+            media_id="238",
+            source=Sources.TMDB.value,
+            media_type=MediaTypes.MOVIE.value,
+            title="The Godfather",
+            image="http://example.com/image.jpg",
+        )
+        Movie.objects.create(
+            item=self.item,
+            user=self.user,
+            status=Status.COMPLETED.value,
+            progress=1,
+        )
+
+    def _get(self, query, media_type=MediaTypes.MOVIE.value):
+        """Request the suggestions fragment for a query/media_type."""
+        return self.client.get(
+            reverse("search_suggestions"),
+            {"q": query, "media_type": media_type},
+        )
+
+    def test_matching_saved_item_is_suggested(self):
+        """A saved item matching the query is returned with a detail link."""
+        response = self._get("godfa")
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "The Godfather")
+        # Links straight to the item detail page.
+        self.assertContains(response, "/details/")
+        # The footer offers the full online search.
+        self.assertContains(response, "Search online for")
+
+    def test_short_query_returns_empty(self):
+        """A single-character query renders nothing (below the min length)."""
+        response = self._get("g")
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "The Godfather")
+        self.assertNotContains(response, "search online")
+
+    def test_non_matching_query_shows_keep_typing_hint(self):
+        """A query with no saved matches shows the search-online hint."""
+        response = self._get("nonexistenttitle")
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "The Godfather")
+        self.assertContains(response, "search online")
+
+    def test_scoped_to_selected_media_type(self):
+        """A saved movie is not suggested when the book type is selected."""
+        response = self._get("godfa", media_type=MediaTypes.BOOK.value)
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "The Godfather")
+
+    def test_only_owners_items_are_suggested(self):
+        """A different user does not see another user's saved items."""
+        other = get_user_model().objects.create_user(
+            username="other-user",
+            password="12345",  # noqa: S106
+        )
+        self.client.force_login(other)
+        response = self._get("godfa")
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "The Godfather")
+
+    def test_requires_authentication(self):
+        """Anonymous requests are redirected by the login-required middleware."""
+        self.client.logout()
+        response = self._get("godfa")
+        self.assertEqual(response.status_code, 302)

--- a/src/app/urls.py
+++ b/src/app/urls.py
@@ -21,6 +21,11 @@ urlpatterns = [
     ),
     path("search", views.media_search, name="search"),
     path(
+        "search/suggestions",
+        views.search_suggestions,
+        name="search_suggestions",
+    ),
+    path(
         "details/music/artist/<int:artist_id>/<slug:artist_slug>/",
         views.music_artist_details,
         name="music_artist_details",

--- a/src/app/views.py
+++ b/src/app/views.py
@@ -282,7 +282,11 @@ from app.score_views import (
     update_media_score,
     update_track_score,
 )
-from app.search_views import _mark_grouped_anime_route, media_search
+from app.search_views import (
+    _mark_grouped_anime_route,
+    media_search,
+    search_suggestions,
+)
 from app.season_details_views import season_details
 from app.services import (
     anime_migration,

--- a/src/static/js/searchAutocomplete.js
+++ b/src/static/js/searchAutocomplete.js
@@ -1,0 +1,115 @@
+// Keyboard navigation for the global search autocomplete dropdown.
+//
+// WAI-ARIA editable-combobox pattern: DOM focus never leaves the text input.
+// Arrow keys move a visual highlight (tracked with aria-activedescendant) over
+// the suggestions, so the user can keep typing at any moment. Enter opens the
+// highlighted item; Enter with nothing highlighted falls through to the form's
+// normal submit, which runs the online search. To get back to an online search
+// after arrowing down, press Up past the first row (returns to the plain text
+// field) or arrow down to the last row, which is the "Search online" action.
+//
+// Bind once: this script is re-evaluated on boosted (hx-boost) navigation.
+if (!window.__yamtrackSearchAutocompleteBound) {
+window.__yamtrackSearchAutocompleteBound = true;
+
+const CONTAINER_ID = 'search-suggestions';
+const INPUT_ID = 'global-search';
+let activeIndex = -1;
+
+function container() {
+  return document.getElementById(CONTAINER_ID);
+}
+
+function input() {
+  return document.getElementById(INPUT_ID);
+}
+
+function options() {
+  const c = container();
+  return c ? Array.from(c.querySelectorAll('[role="option"]')) : [];
+}
+
+function highlight(el, on) {
+  if (!el) return;
+  if (on) {
+    el.style.backgroundColor = '#343a40';
+    el.style.color = '#fff';
+    el.setAttribute('aria-selected', 'true');
+  } else {
+    el.style.backgroundColor = '';
+    el.style.color = '';
+    el.removeAttribute('aria-selected');
+  }
+}
+
+function setActive(index) {
+  const opts = options();
+  opts.forEach((el) => highlight(el, false));
+  const inp = input();
+  if (index < 0 || index >= opts.length) {
+    activeIndex = -1;
+    if (inp) inp.removeAttribute('aria-activedescendant');
+    return;
+  }
+  activeIndex = index;
+  const el = opts[index];
+  if (!el.id) el.id = 'search-suggestion-' + index;
+  highlight(el, true);
+  if (inp) inp.setAttribute('aria-activedescendant', el.id);
+  el.scrollIntoView({ block: 'nearest' });
+}
+
+function reset() {
+  activeIndex = -1;
+  const inp = input();
+  if (inp) {
+    inp.removeAttribute('aria-activedescendant');
+    inp.setAttribute('aria-expanded', options().length > 0 ? 'true' : 'false');
+  }
+}
+
+function clearPanel() {
+  const c = container();
+  if (c) c.innerHTML = '';
+  reset();
+}
+
+document.addEventListener('keydown', (e) => {
+  const inp = input();
+  if (!inp || e.target !== inp) return;
+  const opts = options();
+
+  if (e.key === 'ArrowDown') {
+    if (!opts.length) return;
+    e.preventDefault();
+    setActive(activeIndex + 1 >= opts.length ? opts.length - 1 : activeIndex + 1);
+  } else if (e.key === 'ArrowUp') {
+    if (!opts.length) return;
+    e.preventDefault();
+    // Up from the first row lands on -1 (plain text field, no highlight).
+    setActive(activeIndex - 1);
+  } else if (e.key === 'Enter') {
+    if (activeIndex >= 0 && opts[activeIndex]) {
+      const el = opts[activeIndex];
+      e.preventDefault();
+      if (el.hasAttribute('data-search-online') && inp.form && inp.form.requestSubmit) {
+        // Run the online search using the input's live value.
+        inp.form.requestSubmit();
+      } else {
+        window.location.href = el.getAttribute('href');
+      }
+    }
+    // Nothing highlighted: let the form submit normally (online search).
+  } else if (e.key === 'Escape') {
+    if (opts.length) {
+      e.preventDefault();
+      clearPanel();
+    }
+  }
+});
+
+// Reset highlight state whenever a fresh batch of suggestions is swapped in.
+document.addEventListener('htmx:afterSwap', (e) => {
+  if (e.target && e.target.id === CONTAINER_ID) reset();
+});
+}

--- a/src/templates/app/components/search_suggestions.html
+++ b/src/templates/app/components/search_suggestions.html
@@ -1,0 +1,43 @@
+{% if suggestions %}
+  <div role="listbox"
+       class="absolute z-50 w-full mt-1 overflow-auto text-gray-300 bg-[#2a2e33] rounded-md shadow-lg border border-gray-600 max-h-60">
+    {% for suggestion in suggestions %}
+      <a href="{{ suggestion.url }}"
+         role="option"
+         class="flex items-center gap-3 px-3 py-2 text-sm hover:bg-[#343a40] hover:text-white transition-colors duration-150">
+        {% if suggestion.image and suggestion.image != IMG_NONE %}
+          <img src="{{ suggestion.image }}"
+               alt=""
+               loading="lazy"
+               class="object-cover w-8 h-10 rounded bg-[#3e454d] shrink-0">
+        {% else %}
+          <span class="flex items-center justify-center w-8 h-10 text-gray-600 rounded bg-[#3e454d] shrink-0">
+            {% include "app/icons/magnifying-glass.svg" with classes="w-4 h-4" %}
+          </span>
+        {% endif %}
+        <span class="flex-1 min-w-0">
+          <span class="block truncate">{{ suggestion.title }}</span>
+          {% if suggestion.subtitle %}
+            <span class="block text-xs text-gray-500 truncate">{{ suggestion.subtitle }}</span>
+          {% endif %}
+        </span>
+      </a>
+    {% endfor %}
+    {# Run the full online search (same as pressing Enter with nothing highlighted). #}
+    <a href="{% url 'search' %}?q={{ query|urlencode }}&media_type={{ media_type|urlencode }}"
+       role="option"
+       data-search-online
+       class="flex items-center gap-2 px-3 py-2 text-xs text-gray-400 border-t border-gray-600 hover:bg-[#343a40] hover:text-gray-200 transition-colors duration-150">
+      {% include "app/icons/magnifying-glass.svg" with classes="w-4 h-4 shrink-0" %}
+      <span class="flex-1 min-w-0 truncate">Search online for &ldquo;{{ query }}&rdquo;</span>
+      <span class="hidden sm:inline-flex items-center shrink-0 text-[11px] text-gray-500 border border-gray-600 rounded px-1.5 py-0.5">Enter</span>
+    </a>
+  </div>
+{% elif query %}
+  <div class="absolute z-50 w-full p-3 mt-1 bg-[#2a2e33] rounded-md shadow-lg border border-gray-600">
+    <p class="text-sm text-gray-400">
+      Nothing saved matches &ldquo;{{ query }}&rdquo;. Keep typing and press
+      <span class="text-gray-300">Enter</span> to search online.
+    </p>
+  </div>
+{% endif %}

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -307,7 +307,8 @@
                   <form method="get"
                         action="{% url 'search' %}"
                         x-data="{ isOpen: false, selectedType: { display: '{{ search_type|media_type_readable_plural }}', value: '{{ search_type }}' }, mediaTypes: {% get_search_media_types user as search_types %}{{ search_types }}, getPlaceholder() { return `Search ${this.selectedType.display.toLowerCase()} in your library or online...` }, barcodeScanning: false, barcodeError: null, barcodePreview: null, explicitSubmitTriggered: false, async handleBarcodeImage(event) { if (!event || !event.target) { console.error('[BARCODE] Invalid event or event.target'); return; } if (event.target.tagName !== 'INPUT' || event.target.type !== 'file') { console.error('[BARCODE] Event not from file input. TagName:', event.target.tagName, 'Type:', event.target.type); return; } if (event.target !== this.$refs.barcodeInput) { console.error('[BARCODE] Event not from barcode input ref'); return; } console.log('handleBarcodeImage called', event); const file = event.target.files?.[0]; if (!file) { console.log('No file selected'); return; } console.log('File selected:', file.name, file.type); this.barcodeScanning = true; this.barcodeError = null; this.barcodePreview = URL.createObjectURL(file); try { console.log('Checking for barcodeScannerUtils:', typeof window.barcodeScannerUtils); if (!window.barcodeScannerUtils) { throw new Error('Barcode scanner utilities not loaded. Please refresh the page.'); } console.log('Starting barcode decode...'); const isbn = await window.barcodeScannerUtils.decodeBarcodeFromFile(file); console.log('Decode result:', isbn); if (isbn) { const barcodeInput = event.target; let form = this.$root; if (!form || form.tagName !== 'FORM' || !form.contains(barcodeInput)) { form = barcodeInput.closest('form'); } if (!form || form.tagName !== 'FORM') { console.error('[FORM] Could not find valid form element'); return; } const searchInput = form.querySelector('input[name=q]'); const formContainsBarcodeInput = form.contains(barcodeInput); if (!searchInput || !formContainsBarcodeInput) { console.error('[FORM] Form validation failed - missing search input or barcode input not in form. Search input:', searchInput, 'Form contains barcode input:', formContainsBarcodeInput); return; } console.log('[FORM] ISBN received, form element:', form, 'tagName:', form.tagName); console.log('[FORM] Search input found:', searchInput); searchInput.value = isbn; console.log('[FORM] Set input value to:', isbn, 'Current value:', searchInput.value); this.explicitSubmitTriggered = true; console.log('[FORM] Submitting form...'); form.submit(); console.log('[FORM] Form submit called'); } else { this.barcodeError = 'Could not read barcode from image. Please try again or enter ISBN manually.'; } } catch (error) { console.error('Barcode scan error:', error); this.barcodeError = 'Error scanning barcode: ' + (error.message || 'Please try again.'); } finally { this.barcodeScanning = false; } }, clearBarcodeError() { this.barcodeError = null; this.barcodePreview = null; if (this.$refs.barcodeInput) { this.$refs.barcodeInput.value = ''; } }, handleFormSubmit(event) { if (event.currentTarget !== this.$el) { return true; } if (event.submitter && !this.$el.contains(event.submitter)) { console.log('[FORM] Submitter not in search form, allowing'); return true; } if (event.submitter && !this.$el.contains(event.submitter)) { console.log('[FORM] Submitter not in search form, allowing'); return true; } if (this.explicitSubmitTriggered) { this.explicitSubmitTriggered = false; return true; } if (event.submitter && event.submitter === this.$refs.searchButton) { return true; } if (!event.submitter) { const searchInput = this.$el.querySelector('input[name=q]'); if (searchInput && document.activeElement === searchInput) { return true; } } console.log('[FORM] Form submission prevented - not from search button or Enter key in search input'); event.preventDefault(); event.stopPropagation(); return false; }, init() { console.log('Search form Alpine.js initialized'); this.explicitSubmitTriggered = false; } }"
-                        @submit="handleFormSubmit($event)">
+                        @submit="handleFormSubmit($event)"
+                        @click.away="document.getElementById('search-suggestions').innerHTML = ''">
                     <div class="flex">
                       <div class="relative grow">
                         {# Search input #}
@@ -316,6 +317,16 @@
                                name="q"
                                value="{{ request.GET.q }}"
                                :placeholder="getPlaceholder()"
+                               autocomplete="off"
+                               role="combobox"
+                               aria-autocomplete="list"
+                               aria-expanded="false"
+                               aria-controls="search-suggestions"
+                               hx-get="{% url 'search_suggestions' %}"
+                               hx-trigger="keyup changed delay:250ms, search"
+                               hx-target="#search-suggestions"
+                               hx-swap="innerHTML"
+                               hx-include="[name='media_type']"
                                class="w-full py-2 pl-10 pr-4 text-sm text-gray-300 bg-[#272c31] rounded-l-md focus:outline-none focus:ring-2 focus:ring-[#4a9eff] focus:ring-inset placeholder-gray-500"
                                :class="selectedType.value === 'book' ? 'pr-10' : ''">
                         <button type="submit"
@@ -344,6 +355,8 @@
                                x-ref="barcodeInput"
                                class="hidden"
                                @change="handleBarcodeImage($event)">
+                        {# Saved-library autocomplete suggestions (HTMX-swapped) #}
+                        <div id="search-suggestions"></div>
                       </div>
 
                       <input type="hidden" name="media_type" :value="selectedType.value">
@@ -490,5 +503,6 @@
     <script src="{% static 'js/mediaStatusDateHandler.js' %}{% get_static_file_mtime 'js/mediaStatusDateHandler.js' %}"></script>
     <script src="{% static 'js/episodeBulkTrackForm.js' %}{% get_static_file_mtime 'js/episodeBulkTrackForm.js' %}"></script>
     <script src="{% static 'js/searchShortcut.js' %}{% get_static_file_mtime 'js/searchShortcut.js' %}"></script>
+    <script src="{% static 'js/searchAutocomplete.js' %}{% get_static_file_mtime 'js/searchAutocomplete.js' %}"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
I felt that this feature was missing for two major reasons:
1) Convenience - when you have already tracked an item, it feels tedious to type in the whole name to navigate to it
2) Unnecessary API call - if you only need to navigate to a tracked item, there is no reason you should have to query the API with that item's title just to end up clicking the tracked item on the results page

Although this feature is useful for me, please let me know if it doesn't fit within the scope or vision of the project in some way.

_**Notes on behavior**_
- As demonstrated in the video below, you can navigate the search results with the arrow keys and select them with Enter. You can also click them outright or tap on mobile. 
- Pressing enter without using arrow keys searches local + online as normal, as does navigating down to "Search online for..." hint.
- Video only shows book search, but it looked good for all media types in my testing.

https://github.com/user-attachments/assets/3f1b6f29-7635-49ad-b5b4-4011c85648b3


## Notes
**Code written with the help of Claude Opus.**
